### PR TITLE
fix: resolve LGPD critical issues — hard delete and tenant scope

### DIFF
--- a/src/auth/application/use_case/purge_user_data.ts
+++ b/src/auth/application/use_case/purge_user_data.ts
@@ -1,0 +1,18 @@
+import type { User } from "../../domain/entity/user";
+import type { AuthRepository } from "../../domain/repository/auth_repository";
+import type { UseCase } from "../../../core/application/use_case/use_case";
+import { ResourceNotFoundError } from "../../../core/application/error/resource_not_found_error";
+
+export class PurgeUserDataUseCase implements UseCase<void, void> {
+  constructor(private readonly repository: AuthRepository) {}
+
+  async execute(_input: void, user: User): Promise<void> {
+    const existing = await this.repository.findUserById(user.id);
+
+    if (!existing) {
+      throw new ResourceNotFoundError("User");
+    }
+
+    await this.repository.purgeUserData(user.id);
+  }
+}

--- a/src/auth/domain/repository/auth_repository.ts
+++ b/src/auth/domain/repository/auth_repository.ts
@@ -4,4 +4,5 @@ export interface AuthRepository {
   addUser(input: User): Promise<User>;
   findUserById(id: string): Promise<User | null>;
   findUserByEmail(email: string): Promise<User | null>;
+  purgeUserData(userId: string): Promise<void>;
 }

--- a/src/auth/infra/database/postgres_repository/auth_postgres_repository.ts
+++ b/src/auth/infra/database/postgres_repository/auth_postgres_repository.ts
@@ -1,8 +1,13 @@
-import { eq } from "drizzle-orm";
+import { eq, inArray } from "drizzle-orm";
 import { User, type UserData } from "../../../domain/entity/user";
 import type { AuthRepository } from "../../../domain/repository/auth_repository";
 import { db } from "../../../../core/infra/database/drizzle/database";
-import { usersTable } from "../../../../core/infra/database/drizzle/schema";
+import {
+  usersTable,
+  propertiesTable,
+  addressesTable,
+  externalBookingSources,
+} from "../../../../core/infra/database/drizzle/schema";
 
 export class AuthPostgresRepository implements AuthRepository {
   async findUserById(id: string): Promise<User | null> {
@@ -40,5 +45,29 @@ export class AuthPostgresRepository implements AuthRepository {
     });
 
     return user ? User.reconstitute(user) : null;
+  }
+
+  async purgeUserData(userId: string): Promise<void> {
+    const properties = await db.query.propertiesTable.findMany({
+      where: eq(propertiesTable.user_id, userId),
+      columns: { id: true, address_id: true },
+    });
+
+    const propertyIds = properties.map(p => p.id);
+    const addressIds = properties.map(p => p.address_id);
+
+    if (propertyIds.length > 0) {
+      await db
+        .delete(externalBookingSources)
+        .where(inArray(externalBookingSources.property_id, propertyIds));
+    }
+
+    await db.delete(usersTable).where(eq(usersTable.id, userId));
+
+    if (addressIds.length > 0) {
+      await db
+        .delete(addressesTable)
+        .where(inArray(addressesTable.id, addressIds));
+    }
   }
 }

--- a/src/auth/infra/di/auth_di.ts
+++ b/src/auth/infra/di/auth_di.ts
@@ -5,9 +5,11 @@ import {
 } from "../../application/service/session_manager";
 import { RegisterUserUseCase } from "../../application/use_case/register_user";
 import { SignInUseCase } from "../../application/use_case/sign_in";
+import { PurgeUserDataUseCase } from "../../application/use_case/purge_user_data";
 import { GetUserController } from "../../presentation/controller/auth/get_user.controller";
 import { RegisterUserController } from "../../presentation/controller/auth/register_user.controller";
 import { SignInController } from "../../presentation/controller/auth/sign_in.controller";
+import { PurgeUserDataController } from "../../presentation/controller/auth/purge_user_data.controller";
 import { BunHasher } from "../service/bun_hasher";
 import type { AuthRepository } from "../../domain/repository/auth_repository";
 import { AuthPostgresRepository } from "../database/postgres_repository/auth_postgres_repository";
@@ -49,5 +51,13 @@ export class AuthDi {
   }
   makeGetUserController() {
     return new GetUserController();
+  }
+
+  makePurgeUserDataUseCase() {
+    return new PurgeUserDataUseCase(this.#authRepository);
+  }
+
+  makePurgeUserDataController() {
+    return new PurgeUserDataController(this.makePurgeUserDataUseCase());
   }
 }

--- a/src/auth/presentation/controller/auth/purge_user_data.controller.ts
+++ b/src/auth/presentation/controller/auth/purge_user_data.controller.ts
@@ -1,0 +1,32 @@
+import {
+  HttpControllerMethod,
+  type Controller,
+  type ControllerRequest,
+} from "../../../../core/presentation/controller/controller";
+import type { User } from "../../../domain/entity/user";
+import type { OpenApiOperation } from "../../../../core/presentation/open_api/open_api_types";
+import { PurgeUserDataUseCase } from "../../../application/use_case/purge_user_data";
+import { errorResponse } from "../../../../core/infra/http/swagger/schema_helpers";
+
+export class PurgeUserDataController implements Controller {
+  path = "/auth/me";
+  method = HttpControllerMethod.DELETE;
+
+  openApiSpec: OpenApiOperation = {
+    summary: "Delete account",
+    description:
+      "Permanently deletes the authenticated user's account and all associated personal data (LGPD Art. 17).",
+    tags: ["Auth"],
+    responses: {
+      "204": { description: "Account deleted successfully" },
+      "401": errorResponse("Unauthorized"),
+    },
+  };
+
+  constructor(private readonly useCase: PurgeUserDataUseCase) {}
+
+  async handle(_request: ControllerRequest, user: User): Promise<undefined> {
+    await this.useCase.execute(undefined, user);
+    return undefined;
+  }
+}

--- a/src/booking/application/use_case/tenant/list_tenents.ts
+++ b/src/booking/application/use_case/tenant/list_tenents.ts
@@ -1,5 +1,6 @@
 import type { TenantRepository } from "../../../domain/repository/tenant_repository";
 import type { UseCase } from "../../../../core/application/use_case/use_case";
+import type { User } from "../../../../auth/domain/entity/user";
 
 type Output = {
   id: string;
@@ -7,10 +8,10 @@ type Output = {
   phone: string;
 }[];
 
-export class ListTenantsUseCase implements UseCase {
+export class ListTenantsUseCase implements UseCase<void, Output> {
   constructor(private readonly repository: TenantRepository) {}
 
-  async execute(): Promise<Output> {
-    return this.repository.findAll();
+  async execute(_input: void, user: User): Promise<Output> {
+    return this.repository.findByOwnerProperties(user.id);
   }
 }

--- a/src/booking/domain/repository/tenant_repository.ts
+++ b/src/booking/domain/repository/tenant_repository.ts
@@ -5,4 +5,7 @@ export interface TenantRepository {
   findByPhone(phone: string): Promise<Tenant | null>;
   save(tenant: Tenant): Promise<Tenant>;
   findAll(): Promise<Tenant[]>;
+  findByOwnerProperties(
+    ownerId: string
+  ): Promise<{ id: string; name: string; phone: string }[]>;
 }

--- a/src/booking/infra/database/postgres_repository/tenant_postgres_repository.ts
+++ b/src/booking/infra/database/postgres_repository/tenant_postgres_repository.ts
@@ -1,8 +1,12 @@
-import { eq } from "drizzle-orm";
+import { and, eq, isNull } from "drizzle-orm";
 import { Tenant, type TenantData } from "../../../domain/entity/tenant";
 import type { TenantRepository } from "../../../domain/repository/tenant_repository";
 import { db } from "../../../../core/infra/database/drizzle/database";
-import { tenantsTable } from "../../../../core/infra/database/drizzle/schema";
+import {
+  tenantsTable,
+  staysTable,
+  propertiesTable,
+} from "../../../../core/infra/database/drizzle/schema";
 
 export class TenantPostgresRepository implements TenantRepository {
   async findByPhone(phone: string): Promise<Tenant | null> {
@@ -44,5 +48,31 @@ export class TenantPostgresRepository implements TenantRepository {
     });
 
     return tenant ? Tenant.reconstitute(tenant) : null;
+  }
+
+  async findByOwnerProperties(
+    ownerId: string
+  ): Promise<{ id: string; name: string; phone: string }[]> {
+    const rows = await db
+      .selectDistinct({
+        id: tenantsTable.id,
+        name: tenantsTable.name,
+        phone: tenantsTable.phone,
+      })
+      .from(tenantsTable)
+      .innerJoin(staysTable, eq(staysTable.tenant_id, tenantsTable.id))
+      .innerJoin(
+        propertiesTable,
+        eq(propertiesTable.id, staysTable.property_id)
+      )
+      .where(
+        and(
+          eq(propertiesTable.user_id, ownerId),
+          isNull(tenantsTable.deleted_at),
+          isNull(staysTable.deleted_at)
+        )
+      );
+
+    return rows;
   }
 }

--- a/src/booking/presentation/controller/tenant/list_tenants.controller.ts
+++ b/src/booking/presentation/controller/tenant/list_tenants.controller.ts
@@ -3,12 +3,14 @@ import { ListTenantsUseCase } from "../../../application/use_case/tenant/list_te
 import {
   HttpControllerMethod,
   type Controller,
+  type ControllerRequest,
 } from "../../../../core/presentation/controller/controller";
 import type { OpenApiOperation } from "../../../../core/presentation/open_api/open_api_types";
 import {
   errorResponse,
   responseFromZod,
 } from "../../../../core/infra/http/swagger/schema_helpers";
+import type { User } from "../../../../auth/domain/entity/user";
 
 const outputSchema = z.array(
   z.object({
@@ -24,7 +26,8 @@ export class ListTenantsController implements Controller {
 
   openApiSpec: OpenApiOperation = {
     summary: "List tenants",
-    description: "Returns all tenants registered in the system.",
+    description:
+      "Returns tenants who have stays in properties owned by the authenticated user.",
     tags: ["Tenants"],
     responses: {
       "200": responseFromZod("List of tenants", outputSchema),
@@ -34,8 +37,8 @@ export class ListTenantsController implements Controller {
 
   constructor(private readonly useCase: ListTenantsUseCase) {}
 
-  async handle() {
-    const tenants = await this.useCase.execute();
+  async handle(_request: ControllerRequest, user: User) {
+    const tenants = await this.useCase.execute(undefined, user);
     return tenants;
   }
 }

--- a/src/core/infra/http/routes/routes.ts
+++ b/src/core/infra/http/routes/routes.ts
@@ -124,6 +124,10 @@ const authControllers: Route[] = [
     authenticated: true,
     controller: authDi.makeGetUserController(),
   },
+  {
+    authenticated: true,
+    controller: authDi.makePurgeUserDataController(),
+  },
 ];
 
 const controllers = [


### PR DESCRIPTION
## Summary

- **LGPD Art. 17 (right to erasure):** Add `DELETE /auth/me` endpoint that permanently hard-deletes the authenticated user's account and all associated personal data from the database. Handles cascade order safely: deletes `externalBookingSources` first (no FK cascade), then user (cascades properties → stays + ledger entries), then orphaned addresses.
- **LGPD Art. 6(II) and 9 (purpose limitation):** Scope `GET /tenants` to return only tenants who have stays in properties owned by the authenticated user, instead of exposing all tenants in the database.

## Changes

### Issue 1 — Hard delete / purge (`DELETE /auth/me`)
- `auth/domain/repository/auth_repository.ts` — added `purgeUserData(userId)` to interface
- `auth/infra/database/postgres_repository/auth_postgres_repository.ts` — implemented purge with correct cascade-safe delete order
- `auth/application/use_case/purge_user_data.ts` *(new)* — `PurgeUserDataUseCase`
- `auth/presentation/controller/auth/purge_user_data.controller.ts` *(new)* — `DELETE /auth/me`, returns 204
- `auth/infra/di/auth_di.ts` — factory methods wired
- `core/infra/http/routes/routes.ts` — route registered (authenticated)

### Issue 2 — Tenant scope (`GET /tenants`)
- `booking/domain/repository/tenant_repository.ts` — added `findByOwnerProperties(ownerId)` to interface
- `booking/infra/database/postgres_repository/tenant_postgres_repository.ts` — implemented with `selectDistinct` JOIN (tenants → stays → properties WHERE user_id = owner)
- `booking/application/use_case/tenant/list_tenents.ts` — use case now filters by `user.id`
- `booking/presentation/controller/tenant/list_tenants.controller.ts` — passes authenticated user to use case

## Test plan

- [ ] `DELETE /auth/me` with valid token → 204, user and all related data gone from DB
- [ ] `DELETE /auth/me` with invalid/missing token → 401
- [ ] `GET /tenants` returns only tenants from the caller's properties, not all tenants
- [ ] `GET /tenants` for a user with no properties → empty array
- [ ] Verify cascade: user with properties that have external booking sources purges without FK violation

🤖 Generated with [Claude Code](https://claude.com/claude-code)