### PR TITLE
feat: add GET /dashboard/overview endpoint

### DIFF
--- a/src/booking/application/use_case/dashboard/get_dashboard_overview.ts
+++ b/src/booking/application/use_case/dashboard/get_dashboard_overview.ts
@@ -1,0 +1,63 @@
+import type { UseCase } from "../../../../core/application/use_case/use_case";
+import type { PropertyRepository } from "../../../../property_management/domain/repository/property_repository";
+import type { StayRepository } from "../../../domain/repository/stay_repository";
+import type { LedgerEntryRepository } from "../../../../finance/domain/repository/ledger_entry_repository";
+
+export class GetDashboardOverviewUseCase implements UseCase<Input, Output> {
+  constructor(
+    private readonly propertyRepository: PropertyRepository,
+    private readonly stayRepository: StayRepository,
+    private readonly ledgerEntryRepository: LedgerEntryRepository
+  ) {}
+
+  async execute(input: Input): Promise<Output> {
+    const now = input.date ?? new Date();
+    const date = new Date(
+      Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate())
+    );
+
+    const properties = await this.propertyRepository.allFromUser(input.user_id);
+    const propertyIds = properties.map(p => p.id);
+
+    if (propertyIds.length === 0) {
+      return {
+        kpis: { active_stays: 0, upcoming_check_ins: 0, monthly_revenue: 0 },
+        upcoming_stays: [],
+      };
+    }
+
+    const [stats, monthly_revenue] = await Promise.all([
+      this.stayRepository.dashboardStats(propertyIds, date),
+      this.ledgerEntryRepository.monthlyRevenueForProperties(propertyIds, date),
+    ]);
+
+    return {
+      kpis: {
+        active_stays: stats.active_stays,
+        upcoming_check_ins: stats.upcoming_check_ins,
+        monthly_revenue,
+      },
+      upcoming_stays: stats.upcoming_stays,
+    };
+  }
+}
+
+type Input = {
+  user_id: string;
+  date?: Date;
+};
+
+type Output = {
+  kpis: {
+    active_stays: number;
+    upcoming_check_ins: number;
+    monthly_revenue: number;
+  };
+  upcoming_stays: Array<{
+    id: string;
+    property_id: string;
+    property_name: string;
+    check_in: Date;
+    tenant: { name: string };
+  }>;
+};

--- a/src/booking/domain/repository/stay_repository.ts
+++ b/src/booking/domain/repository/stay_repository.ts
@@ -15,6 +15,18 @@ export type AllFromPropertyFilters = {
   to?: Date;
 };
 
+export type DashboardStatsResult = {
+  active_stays: number;
+  upcoming_check_ins: number;
+  upcoming_stays: Array<{
+    id: string;
+    property_id: string;
+    property_name: string;
+    check_in: Date;
+    tenant: { name: string };
+  }>;
+};
+
 export interface StayRepository {
   stayOfId(id: string): Promise<Stay | null>;
   saveStay(stay: Stay): Promise<void>;
@@ -25,4 +37,8 @@ export interface StayRepository {
     filters?: AllFromPropertyFilters
   ): Promise<PaginatedResult<StayWithTenant>>;
   tenantWithPhone(phone: string): Promise<Tenant | null>;
+  dashboardStats(
+    propertyIds: string[],
+    date: Date
+  ): Promise<DashboardStatsResult>;
 }

--- a/src/booking/infra/database/postgres_repository/stay_postgres_repository.ts
+++ b/src/booking/infra/database/postgres_repository/stay_postgres_repository.ts
@@ -1,7 +1,8 @@
-import { and, count, eq, gte, isNull, lte } from "drizzle-orm";
+import { and, count, eq, gt, gte, inArray, isNull, lte } from "drizzle-orm";
 import { Stay } from "../../../domain/entity/stay";
 import type {
   AllFromPropertyFilters,
+  DashboardStatsResult,
   StayRepository,
   StayWithTenant,
 } from "../../../domain/repository/stay_repository";
@@ -118,6 +119,69 @@ export class StayPostgresRepository implements StayRepository {
         pagination.limit,
         total
       ),
+    };
+  }
+
+  async dashboardStats(
+    propertyIds: string[],
+    date: Date
+  ): Promise<DashboardStatsResult> {
+    const startOfDay = new Date(
+      Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate())
+    );
+    const sevenDaysLater = new Date(startOfDay);
+    sevenDaysLater.setUTCDate(sevenDaysLater.getUTCDate() + 7);
+
+    const baseWhere = and(
+      inArray(staysTable.property_id, propertyIds),
+      isNull(staysTable.deleted_at)
+    );
+
+    const [activeResult, upcomingCheckInsResult, upcomingStays] =
+      await Promise.all([
+        db
+          .select({ count: count() })
+          .from(staysTable)
+          .where(
+            and(
+              baseWhere,
+              lte(staysTable.check_in, startOfDay),
+              gte(staysTable.check_out, startOfDay)
+            )
+          ),
+        db
+          .select({ count: count() })
+          .from(staysTable)
+          .where(
+            and(
+              baseWhere,
+              gt(staysTable.check_in, startOfDay),
+              lte(staysTable.check_in, sevenDaysLater)
+            )
+          ),
+        db.query.staysTable.findMany({
+          where: and(baseWhere, gt(staysTable.check_in, startOfDay)),
+          with: {
+            tenant: true,
+            property: true,
+          },
+          orderBy: (staysTable, { asc }) => [asc(staysTable.check_in)],
+          limit: 5,
+        }),
+      ]);
+
+    return {
+      active_stays: activeResult[0]?.count ? Number(activeResult[0].count) : 0,
+      upcoming_check_ins: upcomingCheckInsResult[0]?.count
+        ? Number(upcomingCheckInsResult[0].count)
+        : 0,
+      upcoming_stays: upcomingStays.map(stay => ({
+        id: stay.id,
+        property_id: stay.property_id,
+        property_name: stay.property.name,
+        check_in: stay.check_in,
+        tenant: { name: stay.tenant.name },
+      })),
     };
   }
 

--- a/src/booking/infra/di/stay_di.ts
+++ b/src/booking/infra/di/stay_di.ts
@@ -3,12 +3,14 @@ import { GetStayUseCase } from "../../application/use_case/stay/get_stay";
 import { FindPropertyStaysUseCase } from "../../application/use_case/stay/find_property_stays";
 import { CancelStayUseCase } from "../../application/use_case/stay/cancel_stay";
 import { UpdateStayUseCase } from "../../application/use_case/stay/update_stay";
+import { GetDashboardOverviewUseCase } from "../../application/use_case/dashboard/get_dashboard_overview";
 import type { StayRepository } from "../../domain/repository/stay_repository";
 import { GetPublicStayController } from "../../presentation/controller/stay/get_public_stay.controller";
 import { GetStayController } from "../../presentation/controller/stay/get_stay.controller";
 import { FindPropertyStaysController } from "../../presentation/controller/stay/find_property_stays.controller";
 import { CancelStayController } from "../../presentation/controller/stay/cancel_stay.controller";
 import { UpdateStayController } from "../../presentation/controller/stay/update_stay.controller";
+import { GetDashboardOverviewController } from "../../presentation/controller/dashboard/get_dashboard_overview.controller";
 import { StayPostgresRepository } from "../database/postgres_repository/stay_postgres_repository";
 import type { TenantRepository } from "../../domain/repository/tenant_repository";
 import { TenantPostgresRepository } from "../database/postgres_repository/tenant_postgres_repository";
@@ -25,6 +27,8 @@ import { ConsoleLogger } from "../../../core/infra/logger/console_logger";
 import type { DeviceManagementService } from "../../domain/service/device_management";
 import { TuyaDeviceManagementService } from "../service/tuya_device_management";
 import { tuyaContext } from "../../../core/infra/config/tuya";
+import { LedgerEntryPostgresRepository } from "../../../finance/infra/database/postgres_repository/ledger_entry_postgres_repository";
+import type { LedgerEntryRepository } from "../../../finance/domain/repository/ledger_entry_repository";
 
 export class StayDi {
   #logger: Logger;
@@ -34,6 +38,7 @@ export class StayDi {
   #eventDispatcher: EventDispatcher;
   #bookingPolicy: BookingPolicy;
   #deviceManagementService: DeviceManagementService;
+  #ledgerEntryRepository: LedgerEntryRepository;
 
   constructor() {
     this.#logger = new ConsoleLogger();
@@ -41,6 +46,7 @@ export class StayDi {
     this.#stayRepository = new StayPostgresRepository();
     this.#tenantRepository = new TenantPostgresRepository();
     this.#bookingPolicy = new PostgresBookingPolicy();
+    this.#ledgerEntryRepository = new LedgerEntryPostgresRepository();
     this.#deviceManagementService = new TuyaDeviceManagementService(
       tuyaContext,
       this.#logger
@@ -87,6 +93,13 @@ export class StayDi {
       this.#bookingPolicy
     );
   }
+  makeGetDashboardOverviewUseCase() {
+    return new GetDashboardOverviewUseCase(
+      this.#propertyRepository,
+      this.#stayRepository,
+      this.#ledgerEntryRepository
+    );
+  }
 
   // Controllers
   makeGetStayController() {
@@ -103,6 +116,11 @@ export class StayDi {
   }
   makeUpdateStayController() {
     return new UpdateStayController(this.makeUpdateStayUseCase());
+  }
+  makeGetDashboardOverviewController() {
+    return new GetDashboardOverviewController(
+      this.makeGetDashboardOverviewUseCase()
+    );
   }
 
   // Handlers

--- a/src/booking/presentation/controller/dashboard/get_dashboard_overview.controller.ts
+++ b/src/booking/presentation/controller/dashboard/get_dashboard_overview.controller.ts
@@ -15,7 +15,7 @@ import {
 const inputSchema = z.object({
   date: z
     .string()
-    .regex(/^\d{4}-\d{2}-\d{2}$/)
+    .date()
     .transform(s => new Date(`${s}T00:00:00.000Z`))
     .optional(),
 });

--- a/src/booking/presentation/controller/dashboard/get_dashboard_overview.controller.ts
+++ b/src/booking/presentation/controller/dashboard/get_dashboard_overview.controller.ts
@@ -1,0 +1,81 @@
+import { z } from "zod";
+import type { GetDashboardOverviewUseCase } from "../../../application/use_case/dashboard/get_dashboard_overview";
+import type { User } from "../../../../auth/domain/entity/user";
+import {
+  HttpControllerMethod,
+  type Controller,
+  type ControllerRequest,
+} from "../../../../core/presentation/controller/controller";
+import type { OpenApiOperation } from "../../../../core/presentation/open_api/open_api_types";
+import {
+  errorResponse,
+  responseFromZod,
+} from "../../../../core/infra/http/swagger/schema_helpers";
+
+const inputSchema = z.object({
+  date: z
+    .string()
+    .regex(/^\d{4}-\d{2}-\d{2}$/)
+    .transform(s => new Date(`${s}T00:00:00.000Z`))
+    .optional(),
+});
+
+const outputSchema = z.object({
+  kpis: z.object({
+    active_stays: z.number().int(),
+    upcoming_check_ins: z.number().int(),
+    monthly_revenue: z.number().int().describe("Revenue in cents"),
+  }),
+  upcoming_stays: z.array(
+    z.object({
+      id: z.string().uuid(),
+      property_id: z.string().uuid(),
+      property_name: z.string(),
+      check_in: z.string().datetime(),
+      tenant: z.object({
+        name: z.string(),
+      }),
+    })
+  ),
+});
+
+type Input = z.infer<typeof inputSchema>;
+
+export class GetDashboardOverviewController implements Controller {
+  path = "/dashboard/overview";
+  method = HttpControllerMethod.GET;
+  inputSchema = inputSchema;
+
+  openApiSpec: OpenApiOperation = {
+    summary: "Get dashboard overview",
+    description:
+      "Returns KPIs and upcoming stays for the authenticated user's properties.",
+    tags: ["Dashboard"],
+    parameters: [
+      {
+        name: "date",
+        in: "query",
+        required: false,
+        schema: { type: "string", format: "date", example: "2026-06-04" },
+      },
+    ],
+    responses: {
+      "200": responseFromZod("Dashboard overview", outputSchema),
+      "401": errorResponse("Unauthorized"),
+      "422": errorResponse("Validation error"),
+    },
+  };
+
+  constructor(private readonly useCase: GetDashboardOverviewUseCase) {}
+
+  async handle(request: ControllerRequest, user: User) {
+    const input = request.body as Input;
+
+    const output = await this.useCase.execute({
+      user_id: user.id,
+      date: input.date,
+    });
+
+    return output;
+  }
+}

--- a/src/core/infra/http/routes/routes.ts
+++ b/src/core/infra/http/routes/routes.ts
@@ -109,6 +109,10 @@ const stayControllers: Route[] = [
     authenticated: true,
     controller: stayDi.makeUpdateStayController(),
   },
+  {
+    authenticated: true,
+    controller: stayDi.makeGetDashboardOverviewController(),
+  },
 ];
 
 const authControllers: Route[] = [

--- a/src/finance/domain/repository/ledger_entry_repository.ts
+++ b/src/finance/domain/repository/ledger_entry_repository.ts
@@ -17,4 +17,8 @@ export interface LedgerEntryRepository {
     pagination: PaginationInput,
     dateFilter?: DateFilter
   ): Promise<PaginatedResult<LedgerEntry>>;
+  monthlyRevenueForProperties(
+    propertyIds: string[],
+    date: Date
+  ): Promise<number>;
 }

--- a/src/finance/infra/database/postgres_repository/ledger_entry_postgres_repository.ts
+++ b/src/finance/infra/database/postgres_repository/ledger_entry_postgres_repository.ts
@@ -1,4 +1,15 @@
-import { and, eq, gt, gte, inArray, lte, sum, count, desc } from "drizzle-orm";
+import {
+  and,
+  count,
+  desc,
+  eq,
+  gt,
+  gte,
+  inArray,
+  isNull,
+  lte,
+  sum,
+} from "drizzle-orm";
 import {
   LedgerEntry,
   type LedgerEntryData,
@@ -60,7 +71,8 @@ export class LedgerEntryPostgresRepository implements LedgerEntryRepository {
           inArray(ledgerEntriesTable.property_id, propertyIds),
           gt(ledgerEntriesTable.amount, 0),
           gte(ledgerEntriesTable.created_at, start),
-          lte(ledgerEntriesTable.created_at, end)
+          lte(ledgerEntriesTable.created_at, end),
+          isNull(ledgerEntriesTable.deleted_at)
         )
       );
 

--- a/src/finance/infra/database/postgres_repository/ledger_entry_postgres_repository.ts
+++ b/src/finance/infra/database/postgres_repository/ledger_entry_postgres_repository.ts
@@ -1,4 +1,4 @@
-import { and, eq, gte, lte, sum, count, desc } from "drizzle-orm";
+import { and, eq, gt, gte, inArray, lte, sum, count, desc } from "drizzle-orm";
 import {
   LedgerEntry,
   type LedgerEntryData,
@@ -40,6 +40,29 @@ export class LedgerEntryPostgresRepository implements LedgerEntryRepository {
       .select({ total: sum(ledgerEntriesTable.amount) })
       .from(ledgerEntriesTable)
       .where(eq(ledgerEntriesTable.property_id, propertyId));
+
+    const total = result[0]?.total;
+    return total ? Number(total) : 0;
+  }
+
+  async monthlyRevenueForProperties(
+    propertyIds: string[],
+    date: Date
+  ): Promise<number> {
+    const start = new Date(date.getFullYear(), date.getMonth(), 1);
+    const end = new Date(date.getFullYear(), date.getMonth() + 1, 1);
+
+    const result = await db
+      .select({ total: sum(ledgerEntriesTable.amount) })
+      .from(ledgerEntriesTable)
+      .where(
+        and(
+          inArray(ledgerEntriesTable.property_id, propertyIds),
+          gt(ledgerEntriesTable.amount, 0),
+          gte(ledgerEntriesTable.created_at, start),
+          lte(ledgerEntriesTable.created_at, end)
+        )
+      );
 
     const total = result[0]?.total;
     return total ? Number(total) : 0;


### PR DESCRIPTION
Closes #12

## Summary

- Novo endpoint `GET /dashboard/overview` (autenticado) que agrega KPIs e próximas estadias para o usuário autenticado
- Retorna `active_stays`, `upcoming_check_ins`, `monthly_revenue` e lista das próximas 5 estadias com nome da propriedade e do hóspede
- `monthly_revenue` usa `LedgerEntry` (Finance) — receita realizada, não contratada
- `date` como query param opcional (default = hoje, UTC)

## Arquitetura

- Feature no BC **Booking** como use case orquestrador — sem novo BC
- Finance recebe `propertyIds[]` (não `userId`) para preservar a fronteira do contexto
- Todas as queries filtram `deleted_at IS NULL` e escopam por `properties.user_id`

## Arquivos

| Ação | Arquivo |
|------|---------|
| criar | `src/booking/application/use_case/dashboard/get_dashboard_overview.ts` |
| criar | `src/booking/presentation/controller/dashboard/get_dashboard_overview.controller.ts` |
| modificar | `src/booking/domain/repository/stay_repository.ts` |
| modificar | `src/booking/infra/database/postgres_repository/stay_postgres_repository.ts` |
| modificar | `src/booking/infra/di/stay_di.ts` |
| modificar | `src/finance/domain/repository/ledger_entry_repository.ts` |
| modificar | `src/finance/infra/database/postgres_repository/ledger_entry_postgres_repository.ts` |
| modificar | `src/core/infra/http/routes/routes.ts` |

## Test plan

- [ ] `GET /dashboard/overview` sem token → 401
- [ ] `GET /dashboard/overview` com `date=2026-13-40` → 422
- [ ] `GET /dashboard/overview` sem `date` → 200 com data de hoje
- [ ] Resposta só retorna dados das propriedades do usuário autenticado
- [ ] `monthly_revenue` não inclui lançamentos com `deleted_at` preenchido

🤖 Generated with [Claude Code](https://claude.com/claude-code)