### PR TITLE
fix: enforce max length on all free-text input fields

### DIFF
--- a/.claude/plans/2026-06-05-input-max-length.md
+++ b/.claude/plans/2026-06-05-input-max-length.md
@@ -1,0 +1,189 @@
+# Input Max Length Hardening
+
+## Objective
+
+Add a maximum character limit (`.max(N)`) to every free-text `z.string()` field
+across the HTTP input schemas (controllers) and the corresponding domain entity
+schemas. Unbounded text fields allow arbitrarily long strings, which is a DoS
+vector — most critically `password`, since bcrypt/argon2 hashing of very long
+inputs blocks the event loop. This change adds the missing limits without
+altering any business logic.
+
+## Personas
+
+- **Arquiteto** (`.claude/personas/arquiteto.md`) — produced this plan and the
+  field-by-field mapping and limit decisions.
+- **Desenvolvedor** (`.claude/personas/desenvolvedor.md`) — implements the
+  `.max()` additions per the guidelines below.
+- **Analista de Segurança** (`.claude/personas/analista_seguranca.md`) —
+  post-implementation security/LGPD review (DoS surface, no PII leakage in
+  error messages).
+
+## Limit Reference Table
+
+| Field type                        | Limit | Rationale                          |
+| --------------------------------- | ----- | ---------------------------------- |
+| `password`                        | 128   | bcrypt safe input ceiling, DoS     |
+| `email`                           | 255   | RFC 5321 max address length        |
+| `name` / free text (person/place) | 100   | Generous human-name / label limit  |
+| address line (street, city, etc.) | 100   | Free-text address component        |
+| `zip_code`                        | 20    | Covers international postal codes  |
+| `complement`                      | 100   | Free-text address note             |
+| `category` (finance)              | 50    | Short enum-like label              |
+| `description` (finance free text) | 500   | Long-form note, still bounded      |
+| `sync_url` (external integration) | 2048  | De-facto browser/URL max length    |
+| `phone`                           | 15/20 | Already bounded in tenant (max 15) |
+
+> Numeric fields, dates, enums, and UUIDs are out of scope — they are not
+> `z.string()` free text and already constrain length implicitly.
+
+## Mapped Changes
+
+### Auth
+
+**`src/auth/presentation/controller/auth/register_user.controller.ts`**
+
+- `name: z.string().min(3)` → add `.max(100, "Name must be at most 100 characters")`
+- `email: z.email()` → add `.max(255, "Email must be at most 255 characters")`
+- `password: z.string().min(8)` → add `.max(128, "Password must be at most 128 characters")` **(critical — DoS)**
+
+**`src/auth/presentation/controller/auth/sign_in.controller.ts`**
+
+- `email: z.email()` → add `.max(255, "Email must be at most 255 characters")`
+- `password: z.string()` → add `.max(128, "Password must be at most 128 characters")` **(critical — DoS)**
+
+**`src/auth/domain/entity/user.ts`** (`userSchema`)
+
+- `name: z.string().min(1)` → add `.max(100)`
+- `email: z.string().email()` → add `.max(255)`
+- `password: z.string().min(8)` → add `.max(128)` **(domain invariant — critical)**
+
+### Booking
+
+**`src/booking/presentation/controller/property/book_stay.controller.ts`**
+
+- `tenant.name: z.string().min(2, "Name is required")` → add `.max(100, "Name must be at most 100 characters")`
+- `tenant.phone: z.string().length(13)` — already bounded (OK, no change)
+- `entrance_code: z.string().length(7, ...)` — already bounded (OK)
+- `source: z.string().max(100)` — already bounded (OK)
+
+**`src/booking/presentation/controller/property/create_external_booking.controller.ts`**
+
+- `sync_url: z.url()` → add `.max(2048, "Sync URL must be at most 2048 characters")`
+- `property_id: z.string()` → tighten to `z.uuid("Property ID must be a valid UUID")` (UUID already implies bounded length; this also fixes a latent validation gap). If a non-UUID change is undesired, fall back to `z.string().max(100)`.
+
+**`src/booking/domain/entity/tenant.ts`** (`tenantSchema`)
+
+- `name: z.string().min(3)` → add `.max(100)`
+- `phone` — already `.max(15)` (OK)
+
+**`src/booking/domain/entity/external_booking_source.ts`** (`externalBookingSourceSchema`)
+
+- `sync_url: z.url()` → add `.max(2048)` (domain invariant)
+
+> `src/booking/domain/entity/stay.ts` — `entrance_code` (`.length(7)`) and
+> `source` (`.max(100)`) are already bounded. No change.
+
+### Finance
+
+**`src/finance/presentation/controller/record_expense.controller.ts`**
+
+- `description: z.string().optional()...` → add `.max(500, "Description must be at most 500 characters")` before `.optional()`
+- `category: z.string().min(1, "Category is required")` → add `.max(50, "Category must be at most 50 characters")`
+
+**`src/finance/presentation/controller/record_revenue.controller.ts`**
+
+- `description: z.string().optional()...` → add `.max(500, "Description must be at most 500 characters")` before `.optional()`
+- `category: z.string().min(1, "Category is required")` → add `.max(50, "Category must be at most 50 characters")`
+
+**`src/finance/domain/entity/ledger_entry.ts`** (`ledgerEntrySchema`)
+
+- `description: z.string().nullable()` → add `.max(500)` before `.nullable()`
+- `category: z.string()` → add `.max(50)` (domain invariant)
+
+### Property Management
+
+**`src/property_management/presentation/controller/create_property.controller.ts`** (`addressSchema` + `inputSchema`)
+
+- `name: z.string().min(1, "Name is required")` → add `.max(100, "Name must be at most 100 characters")`
+- `address.street` → add `.max(100, "Street must be at most 100 characters")`
+- `address.number` → add `.max(20, "Number must be at most 20 characters")`
+- `address.neighborhood` → add `.max(100, "Neighborhood must be at most 100 characters")`
+- `address.city` → add `.max(100, "City must be at most 100 characters")`
+- `address.state` → add `.max(100, "State must be at most 100 characters")`
+- `address.zip_code` → add `.max(20, "Zip code must be at most 20 characters")`
+- `address.country` → add `.max(100, "Country must be at most 100 characters")`
+- `address.complement: z.string().default("")` → add `.max(100, "Complement must be at most 100 characters")` before `.default("")`
+- `images: z.array(z.string())` — each entry is effectively a URL; add `z.string().max(2048)` on the array element to cap individual image strings.
+
+**`src/property_management/presentation/controller/update_property.controller.ts`** (`addressSchema` + `inputSchema`)
+
+- Apply the exact same `.max()` additions as `create_property` for `name`,
+  all address fields, `complement`, and the `images` array element.
+
+**`src/property_management/domain/value_object/address.ts`** (`addressSchema`)
+
+- Apply the same address-field `.max()` limits (domain invariant): `street`,
+  `number`, `neighborhood`, `city`, `state`, `zip_code`, `country`, `complement`.
+
+**`src/property_management/domain/entity/property.ts`** (`propertySchema`)
+
+- `name` → `.max(100)`
+- inline `address.*` fields → same `.max()` limits as above
+- `images` array element → `z.string().max(2048)`
+
+> Note: the address schema is duplicated in three places (controllers, the
+> `address` value object, and the inline `address` in `propertySchema`). All
+> must receive matching limits. A follow-up refactor to share a single
+> `addressSchema` is recommended but **out of scope** for this task.
+
+### Controllers with no free-text input (no change required)
+
+- `src/auth/presentation/controller/auth/get_user.controller.ts` — no inputSchema
+- `src/auth/presentation/controller/auth/purge_user_data.controller.ts` — no inputSchema
+- `src/booking/presentation/controller/property/reconcile_external_booking.controller.ts` — no inputSchema
+- `src/booking/presentation/controller/stay/cancel_stay.controller.ts` — UUID only
+- `src/booking/presentation/controller/stay/find_property_stays.controller.ts` — UUID/date/number only
+- `src/booking/presentation/controller/stay/get_public_stay.controller.ts` — UUID only
+- `src/booking/presentation/controller/stay/get_stay.controller.ts` — UUID only
+- `src/booking/presentation/controller/stay/update_stay.controller.ts` — UUID/date/number only
+- `src/booking/presentation/controller/tenant/list_tenants.controller.ts` — no inputSchema
+- `src/finance/presentation/controller/find_property_financial_movements.controller.ts` — UUID/date/number only
+- `src/property_management/presentation/controller/find_property.controller.ts` — UUID only
+- `src/property_management/presentation/controller/find_user_properties.controller.ts` — no inputSchema
+- `src/core/presentation/controller/health/health.controller.ts` — no inputSchema
+
+## Developer Guidelines
+
+- Add `.max(N)` only — do not touch business logic, ordering of validators
+  (place `.max()` adjacent to existing `.min()`/`.length()`), or use-case code.
+- Zod error messages must be in **English** and descriptive, e.g.
+  `"Password must be at most 128 characters"`.
+- For a field that is `.optional()` / `.nullable()` / `.default()`, the `.max()`
+  must come **before** those modifiers (apply on the base `z.string()`).
+- Where the controller and the domain entity both validate the same field, add
+  the limit in **both** places: the controller is the HTTP boundary; the entity
+  is the domain invariant.
+- `email: z.email()` (Zod v4 top-level format) still supports `.max()` chaining;
+  apply `.max(255)` directly.
+- After each modified file (or each logical group), create a Conventional Commit
+  per the project convention (`fix:` or `chore:`), as required by CLAUDE.md.
+- Run `bun run lint:check` and `bun run format:check` before finishing.
+
+## Tasks
+
+1. **Auth limits** — add `.max()` to `register_user` and `sign_in` controllers and to `userSchema` in `user.ts` (`password` 128, `email` 255, `name` 100).
+   - Dependencies: none
+2. **Booking limits** — add `.max()` to `book_stay` (`tenant.name`) and `create_external_booking` (`sync_url`, tighten `property_id`) controllers, and to `tenantSchema` (`name`) and `externalBookingSourceSchema` (`sync_url`).
+   - Dependencies: none
+3. **Finance limits** — add `.max()` to `record_expense` and `record_revenue` controllers (`description`, `category`) and to `ledgerEntrySchema`.
+   - Dependencies: none
+4. **Property management limits** — add `.max()` to `create_property` and `update_property` controllers, to the `address` value object schema, and to the inline `propertySchema` address + `name` + `images`.
+   - Dependencies: none
+5. **Lint, format & verify** — run `bun run lint:check` and `bun run format:check`; fix any formatting drift introduced by the edits.
+   - Dependencies: tasks 1, 2, 3, 4
+6. **Security review** — Analista de Segurança validates the DoS surface is closed (especially `password`) and that no new error message leaks PII.
+   - Dependencies: task 5
+
+> Tasks 1–4 share no dependencies and can be executed in parallel by multiple
+> agents. Tasks 5 and 6 are sequential gates.

--- a/src/auth/domain/entity/user.ts
+++ b/src/auth/domain/entity/user.ts
@@ -5,9 +5,9 @@ import {
 import { z } from "zod";
 
 export const userSchema = baseEntitySchema.extend({
-  name: z.string().min(1),
-  email: z.string().email(),
-  password: z.string().min(8),
+  name: z.string().min(1).max(100),
+  email: z.string().email().max(255),
+  password: z.string().min(8).max(128),
 });
 
 export type UserData = z.infer<typeof userSchema>;

--- a/src/auth/presentation/controller/auth/register_user.controller.ts
+++ b/src/auth/presentation/controller/auth/register_user.controller.ts
@@ -14,9 +14,12 @@ import {
 } from "../../../../core/infra/http/swagger/schema_helpers";
 
 const inputSchema = z.object({
-  name: z.string().min(3),
-  email: z.email(),
-  password: z.string().min(8),
+  name: z.string().min(3).max(100, "Name must be at most 100 characters"),
+  email: z.email().max(255, "Email must be at most 255 characters"),
+  password: z
+    .string()
+    .min(8)
+    .max(128, "Password must be at most 128 characters"),
 });
 
 const outputSchema = z.object({

--- a/src/auth/presentation/controller/auth/sign_in.controller.ts
+++ b/src/auth/presentation/controller/auth/sign_in.controller.ts
@@ -14,8 +14,8 @@ import {
 } from "../../../../core/infra/http/swagger/schema_helpers";
 
 const inputSchema = z.object({
-  email: z.email(),
-  password: z.string(),
+  email: z.email().max(255, "Email must be at most 255 characters"),
+  password: z.string().max(128, "Password must be at most 128 characters"),
 });
 
 const outputSchema = z.object({

--- a/src/booking/domain/entity/external_booking_source.ts
+++ b/src/booking/domain/entity/external_booking_source.ts
@@ -9,7 +9,7 @@ export type ExternalBookingSourcePlatformName = "AIRBNB" | "BOOKING";
 export const externalBookingSourceSchema = baseEntitySchema.extend({
   property_id: z.uuidv4(),
   platform_name: z.enum(["AIRBNB", "BOOKING"]),
-  sync_url: z.url(),
+  sync_url: z.url().max(2048),
 });
 
 export type ExternalBookingSourceData = z.infer<

--- a/src/booking/domain/entity/tenant.ts
+++ b/src/booking/domain/entity/tenant.ts
@@ -9,7 +9,7 @@ export const tenantSexSchema = z.enum(["MALE", "FEMALE", "OTHER"]);
 export type TenantSex = z.infer<typeof tenantSexSchema>;
 
 export const tenantSchema = baseEntitySchema.extend({
-  name: z.string().min(3),
+  name: z.string().min(3).max(100),
   phone: z
     .string()
     .regex(/^[0-9]+$/, "Phone must contain only numbers")

--- a/src/booking/presentation/controller/property/book_stay.controller.ts
+++ b/src/booking/presentation/controller/property/book_stay.controller.ts
@@ -27,7 +27,10 @@ const inputSchema = z.object({
     .int()
     .min(0, "Price must be a non-negative integer representing cents"),
   tenant: z.object({
-    name: z.string().min(2, "Name is required"),
+    name: z
+      .string()
+      .min(2, "Name is required")
+      .max(100, "Name must be at most 100 characters"),
     phone: z.string().length(13),
     sex: z.enum(["MALE", "FEMALE", "OTHER"]),
   }),

--- a/src/booking/presentation/controller/property/create_external_booking.controller.ts
+++ b/src/booking/presentation/controller/property/create_external_booking.controller.ts
@@ -16,8 +16,8 @@ import {
 
 const inputSchema = z.object({
   platform_name: z.enum(["AIRBNB", "BOOKING"]),
-  sync_url: z.url(),
-  property_id: z.string(),
+  sync_url: z.url().max(2048, "Sync URL must be at most 2048 characters"),
+  property_id: z.string().uuid("Property ID must be a valid UUID"),
 });
 
 const outputSchema = z.object({

--- a/src/finance/domain/entity/ledger_entry.ts
+++ b/src/finance/domain/entity/ledger_entry.ts
@@ -7,8 +7,8 @@ import { ValidationError } from "../../../core/application/error/validation_erro
 
 export const ledgerEntrySchema = baseEntitySchema.extend({
   amount: z.int(),
-  description: z.string().nullable(),
-  category: z.string(),
+  description: z.string().max(500).nullable(),
+  category: z.string().max(50),
   property_id: z.uuidv4(),
 });
 

--- a/src/finance/presentation/controller/record_expense.controller.ts
+++ b/src/finance/presentation/controller/record_expense.controller.ts
@@ -17,9 +17,13 @@ const inputSchema = z.object({
   amount: z.int(),
   description: z
     .string()
+    .max(500, "Description must be at most 500 characters")
     .optional()
     .transform(val => val ?? null),
-  category: z.string().min(1, "Category is required"),
+  category: z
+    .string()
+    .min(1, "Category is required")
+    .max(50, "Category must be at most 50 characters"),
   property_id: z.uuidv4("Property ID must be a valid UUID"),
 });
 

--- a/src/finance/presentation/controller/record_revenue.controller.ts
+++ b/src/finance/presentation/controller/record_revenue.controller.ts
@@ -17,9 +17,13 @@ const inputSchema = z.object({
   amount: z.int(),
   description: z
     .string()
+    .max(500, "Description must be at most 500 characters")
     .optional()
     .transform(val => val ?? null),
-  category: z.string().min(1, "Category is required"),
+  category: z
+    .string()
+    .min(1, "Category is required")
+    .max(50, "Category must be at most 50 characters"),
   property_id: z.uuidv4("Property ID must be a valid UUID"),
 });
 

--- a/src/property_management/domain/entity/property.ts
+++ b/src/property_management/domain/entity/property.ts
@@ -8,19 +8,19 @@ import { Address } from "../value_object/address";
 import type { DeepPartial } from "../../../core/application/types/deep_partial";
 
 export const propertySchema = baseEntitySchema.extend({
-  name: z.string().min(1, "Name is required"),
+  name: z.string().min(1, "Name is required").max(100),
   user_id: z.uuidv4("User ID is required and must be a valid UUID"),
   address: z.object({
-    street: z.string().min(1, "Street is required"),
-    number: z.string().min(1, "Number is required"),
-    neighborhood: z.string().min(1, "Neighborhood is required"),
-    city: z.string().min(1, "City is required"),
-    state: z.string().min(1, "State is required"),
-    zip_code: z.string().min(1, "Zip code is required"),
-    country: z.string().min(1, "Country is required"),
-    complement: z.string().default(""),
+    street: z.string().min(1, "Street is required").max(100),
+    number: z.string().min(1, "Number is required").max(20),
+    neighborhood: z.string().min(1, "Neighborhood is required").max(100),
+    city: z.string().min(1, "City is required").max(100),
+    state: z.string().min(1, "State is required").max(100),
+    zip_code: z.string().min(1, "Zip code is required").max(20),
+    country: z.string().min(1, "Country is required").max(100),
+    complement: z.string().max(100).default(""),
   }),
-  images: z.array(z.string()).min(1, "Images are required"),
+  images: z.array(z.string().max(2048)).min(1, "Images are required"),
   capacity: z.number().int().positive("Capacity must be greater than 0"),
 });
 

--- a/src/property_management/domain/value_object/address.ts
+++ b/src/property_management/domain/value_object/address.ts
@@ -1,14 +1,14 @@
 import { z } from "zod";
 
 export const addressSchema = z.object({
-  street: z.string().min(1, "Street is required"),
-  number: z.string().min(1, "Number is required"),
-  neighborhood: z.string().min(1, "Neighborhood is required"),
-  city: z.string().min(1, "City is required"),
-  state: z.string().min(1, "State is required"),
-  zip_code: z.string().min(1, "Zip code is required"),
-  country: z.string().min(1, "Country is required"),
-  complement: z.string().default(""),
+  street: z.string().min(1, "Street is required").max(100),
+  number: z.string().min(1, "Number is required").max(20),
+  neighborhood: z.string().min(1, "Neighborhood is required").max(100),
+  city: z.string().min(1, "City is required").max(100),
+  state: z.string().min(1, "State is required").max(100),
+  zip_code: z.string().min(1, "Zip code is required").max(20),
+  country: z.string().min(1, "Country is required").max(100),
+  complement: z.string().max(100).default(""),
 });
 
 export type AddressData = z.infer<typeof addressSchema>;

--- a/src/property_management/presentation/controller/create_property.controller.ts
+++ b/src/property_management/presentation/controller/create_property.controller.ts
@@ -15,20 +15,49 @@ import {
 } from "../../../core/infra/http/swagger/schema_helpers";
 
 const addressSchema = z.object({
-  street: z.string().min(1, "Street is required"),
-  number: z.string().min(1, "Number is required"),
-  neighborhood: z.string().min(1, "Neighborhood is required"),
-  city: z.string().min(1, "City is required"),
-  state: z.string().min(1, "State is required"),
-  zip_code: z.string().min(1, "Zip code is required"),
-  country: z.string().min(1, "Country is required"),
-  complement: z.string().default(""),
+  street: z
+    .string()
+    .min(1, "Street is required")
+    .max(100, "Street must be at most 100 characters"),
+  number: z
+    .string()
+    .min(1, "Number is required")
+    .max(20, "Number must be at most 20 characters"),
+  neighborhood: z
+    .string()
+    .min(1, "Neighborhood is required")
+    .max(100, "Neighborhood must be at most 100 characters"),
+  city: z
+    .string()
+    .min(1, "City is required")
+    .max(100, "City must be at most 100 characters"),
+  state: z
+    .string()
+    .min(1, "State is required")
+    .max(100, "State must be at most 100 characters"),
+  zip_code: z
+    .string()
+    .min(1, "Zip code is required")
+    .max(20, "Zip code must be at most 20 characters"),
+  country: z
+    .string()
+    .min(1, "Country is required")
+    .max(100, "Country must be at most 100 characters"),
+  complement: z
+    .string()
+    .max(100, "Complement must be at most 100 characters")
+    .default(""),
 });
 
 const inputSchema = z.object({
-  name: z.string().min(1, "Name is required"),
+  name: z
+    .string()
+    .min(1, "Name is required")
+    .max(100, "Name must be at most 100 characters"),
   address: addressSchema,
-  images: z.array(z.string()).min(1, "At least one image is required"),
+  images: z
+    .array(z.string().max(2048, "Image URL must be at most 2048 characters"))
+    .min(1, "At least one image is required"),
   capacity: z.number().int().positive("Capacity must be greater than 0"),
 });
 

--- a/src/property_management/presentation/controller/update_property.controller.ts
+++ b/src/property_management/presentation/controller/update_property.controller.ts
@@ -15,21 +15,34 @@ import {
 } from "../../../core/infra/http/swagger/schema_helpers";
 
 const addressSchema = z.object({
-  street: z.string().min(1),
-  number: z.string().min(1),
-  neighborhood: z.string().min(1),
-  city: z.string().min(1),
-  state: z.string().min(1),
-  zip_code: z.string().min(1),
-  country: z.string().min(1),
-  complement: z.string().default(""),
+  street: z.string().min(1).max(100, "Street must be at most 100 characters"),
+  number: z.string().min(1).max(20, "Number must be at most 20 characters"),
+  neighborhood: z
+    .string()
+    .min(1)
+    .max(100, "Neighborhood must be at most 100 characters"),
+  city: z.string().min(1).max(100, "City must be at most 100 characters"),
+  state: z.string().min(1).max(100, "State must be at most 100 characters"),
+  zip_code: z.string().min(1).max(20, "Zip code must be at most 20 characters"),
+  country: z.string().min(1).max(100, "Country must be at most 100 characters"),
+  complement: z
+    .string()
+    .max(100, "Complement must be at most 100 characters")
+    .default(""),
 });
 
 const inputSchema = z.object({
   property_id: z.uuid(),
-  name: z.string().min(1, "Name is required").optional(),
+  name: z
+    .string()
+    .min(1, "Name is required")
+    .max(100, "Name must be at most 100 characters")
+    .optional(),
   address: addressSchema.partial().optional(),
-  images: z.array(z.string()).min(1, "Images are required").optional(),
+  images: z
+    .array(z.string().max(2048, "Image URL must be at most 2048 characters"))
+    .min(1, "Images are required")
+    .optional(),
   capacity: z
     .number()
     .int()


### PR DESCRIPTION
## Summary

Closes #16

- Added `.max()` constraints to every unbound `z.string()` input field across all bounded contexts (Auth, Booking, Finance, Property Management)
- Limits applied at both HTTP boundary (controllers) and domain invariant (entities/value objects)
- Critical fix: `password ≤ 128` characters prevents bcrypt DoS by blocking arbitrarily long strings before they reach `Bun.password.verify()`

## Limits applied

| Field type | Limit |
|---|---|
| `password` | 128 (bcrypt DoS prevention) |
| `email` | 255 (RFC 5321) |
| `name` / free text | 100 |
| address fields | 100 |
| `zip_code` / `number` | 20 |
| `category` | 50 |
| `description` | 500 |
| `sync_url` / `images[]` | 2048 |

## Test plan

- [ ] `POST /auth/register` with `password` > 128 chars → 422
- [ ] `POST /auth/sign-in` with `password` > 128 chars → 422 (never reaches bcrypt)
- [ ] `POST /auth/register` with `email` > 255 chars → 422
- [ ] `POST /properties` with `name` > 100 chars → 422
- [ ] Existing valid requests unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)