### PR TITLE
Add property-scoped settings (PropertySetting) with HTTP and MCP CRUD

### DIFF
--- a/.claude/plans/2026-08-15-configuracao-por-propriedade.md
+++ b/.claude/plans/2026-08-15-configuracao-por-propriedade.md
@@ -1,0 +1,108 @@
+# Configuração por Propriedade (PropertySetting)
+
+## Objective
+
+A feature de configurações (`AppSetting`, BC `backoffice`) nasceu 100% global: um `key` único no sistema inteiro, mutável apenas por `admin`. Isso não atende o proprietário de imóvel, que precisa de configurações específicas por propriedade (ex.: horário de check-in, tamanho do código da fechadura, taxa de limpeza) sem depender de um administrador da plataforma e sem afetar outras propriedades. Esta tarefa introduz `PropertySetting`, um segundo conceito de configuração key/value, irmão e desacoplado de `AppSetting`, vinculado obrigatoriamente a uma propriedade e autorizado por ownership (dono do imóvel), não por role de admin.
+
+Nenhuma configuração havia sido criada em produção até esta tarefa — não houve necessidade de migração de dados.
+
+## Personas
+
+- **Arquiteto** — análise de domínio: nome do conceito, posição em relação ao agregado `Property`, mecanismo de ownership a extrair, riscos e diretrizes (concluído).
+- **Desenvolvedor** — implementação da entidade, policy, repositório, use cases, controllers, DI, rotas e migration; e, em uma segunda rodada, correção dos achados de segurança priorizados pelo usuário (concluído).
+- **Analista de Segurança** — revisão de segurança e LGPD pós-desenvolvimento (concluído).
+
+## Decisões de Domínio (Arquiteto)
+
+- **Nome:** `PropertySetting`, no BC `property_management` (não em `backoffice`). Termos descartados: `PropertyPreference` (sugere algo cosmético/opcional), `PropertyPolicy` (colide com a linguagem já usada por `BookingPolicy`).
+- **Posição no modelo:** agregado próprio, referenciando `Property` apenas por `property_id` — não é value object dentro de `Property`. Mesmo padrão já usado por `ExternalBookingSource`.
+- **Keyspaces independentes:** `PropertySetting` não sobrescreve `AppSetting` de mesma chave; são dois universos sem relação (decisão validada com o usuário — evita acoplar `property_management` a `backoffice`).
+- **Modelo extensível:** key/value genérico confirmado pelo usuário (não é um conjunto fechado de atributos formais de `Property`).
+- **Ownership:** dono único da propriedade (`properties.user_id`), sem multi-gestor/co-propriedade — confirmado pelo usuário, não introduzido nesta feature.
+- **Duplicação:** `AppSetting` e `PropertySetting` permanecem entidades, repositórios, use cases e controllers independentes (dono, autorização e ciclo de vida diferentes). Apenas a validação do "valor de configuração tipado" (enum de tipos, coerência `type`/`value`, limites de tamanho) foi extraída para `src/core/domain/value_object/setting_value.ts`, compartilhada pelos dois.
+- **Eventos:** nenhum evento de domínio novo — configuração é lida sob demanda, sem consumidor hoje.
+
+## Mapped Changes
+
+- `src/property_management/domain/entity/property_setting.ts` _(novo)_ — entidade `PropertySetting`, consome a validação compartilhada de `setting_value.ts`; docblock reafirma a proibição de segredos/credenciais/PII (fechadura inteligente, tokens de integração externa).
+- `src/property_management/domain/policy/property_ownership_policy.ts` _(novo)_ — `PropertyOwnershipPolicy.ensureOwnership`, rejeita propriedade inexistente, de outro dono, ou soft-deletada, sempre com `ResourceNotFoundError("Property")` (404 indistinguível).
+- `src/property_management/domain/repository/property_setting_repository.ts` _(novo)_ — interface do repositório.
+- `src/property_management/infra/database/postgres_repository/property_setting_postgres_repository.ts` _(novo)_ — implementação Drizzle.
+- `src/property_management/application/use_case/{create,get,list,update,delete}_property_setting.ts` _(novos)_ — todos exigem `property_id`, aplicam a policy de ownership antes de qualquer acesso a dados.
+- `src/property_management/presentation/controller/{create,get,list,update,delete}_property_setting.controller.ts` _(novos)_.
+- `src/property_management/infra/di/property_management_di.ts` _(modificado)_ — wiring dos componentes acima.
+- `src/core/infra/http/routes/routes.ts` _(modificado)_ — 5 rotas novas sob `/property/:property_id/settings...`, todas `authenticated: true`, sem `adminOnly`.
+- `src/core/domain/value_object/setting_value.ts` _(novo)_ — validação compartilhada de valor tipado (`boundedJsonValue`, tipos, limites de tamanho/profundidade/cardinalidade).
+- `src/backoffice/domain/entity/app_setting.ts` _(modificado)_ — refatorado para consumir a extração acima; docblock corrigido de `@bc settings` para `@bc backoffice`.
+- `src/core/infra/database/drizzle/schemas/property_schemas.ts` + migration `drizzle/0004_mighty_morg.sql` _(novos/modificados)_ — tabela `property_settings`, índice único parcial `(property_id, key) WHERE deleted_at IS NULL`.
+
+## Revisão de Segurança (2026-08-15)
+
+Analista de Segurança revisou a implementação antes do merge. Dois achados críticos e cinco moderados foram corrigidos nesta mesma sessão (decisão do usuário, seguindo a recomendação do Analista):
+
+1. **FK `property_settings → properties` (`ON DELETE no action`) quebrava o expurgo LGPD** — `purgeUserData` não deletava as settings antes do `DELETE FROM users`, causando falha por violação de FK (500) e deixando a conta parcialmente destruída (sem transação).
+2. **Limite de 100 configurações ativas por propriedade era um TOCTOU** — "count então insert" sem lock/transação, contornável por requests concorrentes.
+3. Null bytes/caracteres de controle não eram rejeitados em `value`/`description` (caminho para 500 não mapeado).
+4. Soft delete não apagava `value`/`description` — retenção indefinida de possível PII.
+5. A policy de ownership aceitava propriedade soft-deletada.
+6. Proibição de segredos/PII era só documentação, sem controle técnico, e o exemplo do Swagger sugeria guardar instrução de acesso físico ao imóvel.
+7. Nenhuma das 5 rotas tinha rate limit.
+
+Achados informativos, registrados como dívida (não corrigidos nesta sessão, decisão do usuário):
+
+- `update`/`delete` no repositório são escopados só por `id` (sem `property_id`/`deleted_at` na cláusula `WHERE`) — seguro hoje porque os use cases validam antes, mas perde a última rede de proteção para futuros callers.
+- Nenhuma trilha de auditoria de quem alterou qual configuração e quando (além de `updated_at`).
+- `page` no schema de listagem não tem limite superior (só `limit` tem `.max`), permitindo `OFFSET` arbitrariamente grande.
+- `Bun.serve` sem `maxRequestBodySize` — pré-existente e sistêmico, não específico desta feature.
+- `measureDepth` em `setting_value.ts` usa spread de array em `Math.max(...)`, seguro apenas porque o check de 16KB roda antes e limita a cardinalidade — dependência de ordem não documentada.
+- Zero cobertura de teste para as 5 rotas novas (isolamento de ownership é o único controle de autorização da feature e não tem teste de regressão).
+- Diferença de timing residual entre "propriedade não existe" e "propriedade não é sua" (carga da relação `address`) — não explorável remotamente, registrado para completude.
+
+## Exposição via MCP (2026-08-15, branch `feat/property-settings`)
+
+Decisão do usuário: expor `PropertySetting` como 5 tools MCP (`list_property_settings`, `get_property_setting`, `create_property_setting`, `update_property_setting`, `delete_property_setting`), na mesma sessão em que as rotas HTTP CRUD foram implementadas e corrigidas. Isso **reverte a recomendação original R8 do Arquiteto** (registrada anteriormente neste plano) de não expor a feature via MCP na v1 — o usuário optou por expô-la já nesta rodada, aceitando os riscos abaixo em vez de adiar a decisão.
+
+Cada tool embrulha o use case HTTP já existente sem duplicar validação/autorização — a checagem de ownership continua vindo exclusivamente de `PropertyOwnershipPolicy`, executada pelo use case, seguindo o mesmo padrão de `cancel_stay`. Nenhuma mudança foi feita em `src/property_management/domain/` ou `src/property_management/application/`; a implementação é inteiramente wiring em `src/core/infra/mcp/tools/`.
+
+Decisões de design (Arquiteto, seguidas à risca pelo Desenvolvedor):
+
+- **Endereçamento por `id`, não por `key`, na v1.** As tools `get`/`update`/`delete` recebem `id`, e sua descrição instrui explicitamente o agente a obtê-lo via `list_property_settings` primeiro — mesmo padrão já usado por `stay_id` em `cancel_stay`.
+- **`list_property_settings` paginada (20 por página, teto de 100).** A descrição da tool avisa o agente para paginar (via `page`/`limit`, checando `pagination.has_next`) antes de concluir que uma `key` não existe — parar na primeira página é um falso negativo.
+- **Annotations exatas por tool** (`readOnlyHint`/`destructiveHint`/`idempotentHint`): `list`/`get` são `readOnlyHint: true`; `create` é `{false, false, false}`; `update` é `{false, false, true}` (aplicar o mesmo valor de novo produz o mesmo estado); `delete` é `{false, true, false}`, com a descrição afirmando explicitamente que o soft delete apaga `value`/`description` de forma definitiva — não é uma remoção reversível, para o LLM não propor "desfazer" (confirmado no código: `PropertySetting.softDelete()` zera os dois campos).
+- **Texto de consentimento OAuth atualizado no mesmo commit** (`SCOPE_DESCRIPTIONS` em `src/auth/domain/service/oauth_scope_policy.ts`), seguindo o precedente do commit `5bd330b`: o texto agora cobre que o app passa a ler as configurações das propriedades, a alterar e remover essas configurações, e que a remoção apaga o valor permanentemente (não é reversível).
+
+Riscos identificados nesta rodada (nenhum bloqueou a decisão — registrados para acompanhamento):
+
+- **R1 — `value` livre entra no contexto do LLM.** `PropertySetting.value` é conteúdo arbitrário definido pelo próprio usuário (não gerado pelo sistema), o que limita o risco a "o dono da propriedade injeta algo no próprio contexto do seu agente" — não é um vetor de terceiro. Mitigação: nenhuma nova, além da proibição de segredos/PII já existente na entidade (heurística de nome de chave em `settingKeySchema` + docblock).
+- **R2 — `list_property_settings` como vetor de exfiltração em massa.** Uma única chamada devolve até 100 configurações de uma propriedade. Como o escopo OAuth é tudo-ou-nada (`OAUTH_MCP_SCOPE`) e a autorização é só por ownership, um app autorizado mal-intencionado pode enumerar `list_properties` + `list_property_settings` para extrair todo o key/value store do usuário. Não mitigado nesta rodada — mesma classe de risco que já existe para `list_stays`/`list_properties`, não introduzida por esta feature.
+- **R3 — risco de prompt injection se `value` um dia vier de fonte externa.** Hoje `value` só é escrito pelo próprio dono via chamada direta (HTTP ou MCP), nunca por uma integração externa (ex.: sincronização com Airbnb/Booking.com). Se isso mudar no futuro, `value` passaria a ser conteúdo não confiável entrando no contexto do LLM do dono via `list`/`get` — **reabrir esta análise nesse cenário**, antes de qualquer integração que escreva `PropertySetting.value` a partir de dado de terceiro.
+- **R4 — `property_id` é escolhido livremente pelo LLM em toda tool.** Nenhuma tool valida ownership antes de chamar o use case; a proteção real é inteiramente `PropertyOwnershipPolicy.ensureOwnership`, chamada dentro de cada use case. Coberto por teste de isolamento de ownership em `get`, `update` e `delete` (e também em `list` e `create`, como cobertura extra) nesta rodada.
+
+**Dívida de rate limit reenquadrada:** a ausência de rate limit em `/mcp` já era uma dívida pré-existente e isolada (task 14 do plano de OAuth MCP). Com a adição destas 5 tools — 3 delas de escrita/destrutivas (`create`, `update`, `delete`) — essa dívida deixa de ser um detalhe do transporte e passa a ser um contorno ativo: **o MCP agora contorna o controle de rate limit que a rota HTTP equivalente tem** (`CreatePropertySettingController`, `UpdatePropertySettingController` e `DeletePropertySettingController` têm `RATE_LIMIT_POLICY` de 30 tentativas/minuto por IP; as tools MCP equivalentes não têm nenhum limite). Não corrigido nesta sessão — decisão do usuário de tratar como dívida a ser priorizada separadamente, não bloqueadora desta feature.
+
+## Verificação final e bug encontrado (2026-08-15)
+
+Antes do commit, a suíte de testes foi rodada por completo (lint, format, typecheck, e todos os arquivos de teste tocados) diretamente pelo Orquestrador, após uma investigação que descartou dois falsos alarmes:
+
+- **Falso alarme 1 — múltiplos subagentes rodando `bun test` concorrentemente.** Em determinado momento, 4 processos `bun test` chegaram a rodar ao mesmo tempo contra o mesmo banco `stayhub_test` (subagentes re-executando a suíte a cada vez que eram retomados). Isso causava lentidão severa e parecia um travamento. Resolvido matando os processos duplicados e assumindo a verificação final diretamente.
+- **Falso alarme 2 — `property_settings` ausente no banco de teste.** `bun run db:push:test` não aplicava a tabela nova ao `stayhub_test` (aplicava outras mudanças pendentes, mas não o `CREATE TABLE`). Resolvido aplicando a migration manualmente via `psql -f drizzle/0004_mighty_morg.sql`.
+
+**Bug real encontrado e corrigido:** a coluna `property_settings.value` era `jsonb().notNull()` (herdada do padrão de `app_settings.value`). O achado A4 do laudo de segurança (soft delete deve redigir/zerar `value` e `description`) foi implementado corretamente do lado da entidade e do repositório, mas ninguém atualizou a coluna do banco para aceitar `NULL` — toda chamada a `delete_property_setting` (rota HTTP e tool MCP) quebrava com `23502 null value in column "value" violates not-null constraint`. Corrigido:
+
+- `src/core/infra/database/drizzle/schemas/property_schemas.ts`: `value: jsonb()` (removido `.notNull()`).
+- Nova migration `drizzle/0005_absent_squadron_supreme.sql`: `ALTER TABLE "property_settings" ALTER COLUMN "value" DROP NOT NULL`.
+
+**Achado de infraestrutura de teste, registrado como dívida (não corrigido, pré-existente e não relacionado a esta feature):** rodar múltiplos arquivos de teste juntos numa única invocação de `bun test <diretório>` trava de forma intermitente e reprodutível em algum ponto do meio da execução (observado em `tests/auth` sozinho, e em `tests/core` sozinho, ambos sem nenhuma mudança desta feature envolvida). Confirmado que o mesmo travamento ocorre em código **não modificado de `main`** (testado via `git stash` + rerun), portanto não é causado por `PropertySetting`. Cada arquivo individual passa normalmente quando rodado sozinho (`bun test tests/auth/rbac.test.ts`, por exemplo). Suspeita não confirmada: o `tests/setup.ts` cria um único `Bun.serve()` module-level e registra `afterAll(() => server.stop())` fora de um `describe` — quando a suíte roda sem `--preload ./tests/setup.ts` (script `bun run test` correto usa preload; invocações diretas de `bun test <path>` não), esse hook pode ficar associado ao primeiro arquivo que importa o helper, criando comportamento de desligamento não determinístico entre arquivos. Não investigado a fundo por estar fora do escopo desta feature — recomendo que outra tarefa audite `tests/setup.ts` e a ordem de import/preload da suíte.
+
+**Resultado final da verificação** (todos os arquivos rodados individualmente, para contornar o travamento acima):
+
+- `bun run lint:check` — limpo.
+- `bun run format:check` — limpo.
+- `bunx tsc --noEmit` — limpo.
+- `tests/auth` (8 arquivos) — 34 pass, 0 fail.
+- `tests/backoffice` — 31 pass, 0 fail.
+- `tests/property_management` (inclui as 5 tools MCP novas) — 11 pass, 0 fail (após o fix da coluna `value`).
+- `tests/core` (8 arquivos, inclui `mcp_routes.test.ts` com as 10 tools registradas) — 49 pass, 0 fail.
+- `tests/booking` (4 arquivos, inclui `cancel_stay_tool.test.ts`) — 21 pass, 0 fail.
+
+**Achado adicional revertido (não relacionado à feature):** o primeiro subagente Arquiteto, despachado com isolamento de worktree, modificou por conta própria `.claude/personas/orquestrador.md` e `.gitignore`, e criou `.claude/rules/worktree-workflow.md`, introduzindo uma exigência não solicitada de que toda feature futura seja desenvolvida em worktree isolada. Revertido antes do commit por não ter sido pedido pelo usuário nem fazer parte do escopo desta tarefa.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -68,7 +68,13 @@ jobs:
 
             bun install
 
-            bun run db:push
+            # One-time cutover from `db:push` to `db:migrate`: marks the
+            # migrations already applied via `push` as done, so `migrate`
+            # doesn't try to replay them. No-op on every deploy after the
+            # first (see scripts/baseline_drizzle_migrations.ts).
+            bun run db:baseline-migrations
+
+            bun run db:migrate
 
             pm2 restart stayhub_api
 

--- a/drizzle/0004_mighty_morg.sql
+++ b/drizzle/0004_mighty_morg.sql
@@ -1,0 +1,14 @@
+CREATE TABLE "property_settings" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"deleted_at" timestamp with time zone,
+	"property_id" uuid NOT NULL,
+	"key" varchar(255) NOT NULL,
+	"value" jsonb NOT NULL,
+	"type" varchar(20) NOT NULL,
+	"description" varchar(500)
+);
+--> statement-breakpoint
+ALTER TABLE "property_settings" ADD CONSTRAINT "property_settings_property_id_properties_id_fk" FOREIGN KEY ("property_id") REFERENCES "public"."properties"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "property_settings_property_id_key_idx" ON "property_settings" USING btree ("property_id","key") WHERE "property_settings"."deleted_at" is null;

--- a/drizzle/0005_absent_squadron_supreme.sql
+++ b/drizzle/0005_absent_squadron_supreme.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "property_settings" ALTER COLUMN "value" DROP NOT NULL;

--- a/drizzle/meta/0004_snapshot.json
+++ b/drizzle/meta/0004_snapshot.json
@@ -1,0 +1,1423 @@
+{
+  "id": "b606ddf9-1243-4a20-8ee0-16976890a127",
+  "prevId": "622484c0-b356-494e-9c7f-adaefa97fe2f",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password": {
+          "name": "password",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_registrations": {
+      "name": "app_registrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_name": {
+          "name": "client_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_endpoint_auth_method": {
+          "name": "token_endpoint_auth_method",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.authorization_codes": {
+      "name": "authorization_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "code_digest": {
+          "name": "code_digest",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "app_registration_id": {
+          "name": "app_registration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consent_id": {
+          "name": "consent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uri": {
+          "name": "redirect_uri",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_challenge": {
+          "name": "code_challenge",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_challenge_method": {
+          "name": "code_challenge_method",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource": {
+          "name": "resource",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "authorization_codes_app_registration_id_app_registrations_id_fk": {
+          "name": "authorization_codes_app_registration_id_app_registrations_id_fk",
+          "tableFrom": "authorization_codes",
+          "tableTo": "app_registrations",
+          "columnsFrom": [
+            "app_registration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "authorization_codes_consent_id_consents_id_fk": {
+          "name": "authorization_codes_consent_id_consents_id_fk",
+          "tableFrom": "authorization_codes",
+          "tableTo": "consents",
+          "columnsFrom": [
+            "consent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "authorization_codes_code_digest_unique": {
+          "name": "authorization_codes_code_digest_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code_digest"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.authorization_requests": {
+      "name": "authorization_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "identifier_digest": {
+          "name": "identifier_digest",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "app_registration_id": {
+          "name": "app_registration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uri": {
+          "name": "redirect_uri",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_challenge": {
+          "name": "code_challenge",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_challenge_method": {
+          "name": "code_challenge_method",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource": {
+          "name": "resource",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "authorization_requests_app_registration_id_app_registrations_id_fk": {
+          "name": "authorization_requests_app_registration_id_app_registrations_id_fk",
+          "tableFrom": "authorization_requests",
+          "tableTo": "app_registrations",
+          "columnsFrom": [
+            "app_registration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "authorization_requests_identifier_digest_unique": {
+          "name": "authorization_requests_identifier_digest_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "identifier_digest"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.consents": {
+      "name": "consents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "app_registration_id": {
+          "name": "app_registration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "consents_user_id_app_registration_id_idx": {
+          "name": "consents_user_id_app_registration_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "app_registration_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "consents_user_id_users_id_fk": {
+          "name": "consents_user_id_users_id_fk",
+          "tableFrom": "consents",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "consents_app_registration_id_app_registrations_id_fk": {
+          "name": "consents_app_registration_id_app_registrations_id_fk",
+          "tableFrom": "consents",
+          "tableTo": "app_registrations",
+          "columnsFrom": [
+            "app_registration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issued_credentials": {
+      "name": "issued_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consent_id": {
+          "name": "consent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "family_id": {
+          "name": "family_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token_digest": {
+          "name": "access_token_digest",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token_digest": {
+          "name": "refresh_token_digest",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource": {
+          "name": "resource",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "authorization_code_digest": {
+          "name": "authorization_code_digest",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rotated_at": {
+          "name": "rotated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "successor_id": {
+          "name": "successor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "issued_credentials_family_id_idx": {
+          "name": "issued_credentials_family_id_idx",
+          "columns": [
+            {
+              "expression": "family_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issued_credentials_consent_id_consents_id_fk": {
+          "name": "issued_credentials_consent_id_consents_id_fk",
+          "tableFrom": "issued_credentials",
+          "tableTo": "consents",
+          "columnsFrom": [
+            "consent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issued_credentials_successor_id_issued_credentials_id_fk": {
+          "name": "issued_credentials_successor_id_issued_credentials_id_fk",
+          "tableFrom": "issued_credentials",
+          "tableTo": "issued_credentials",
+          "columnsFrom": [
+            "successor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "issued_credentials_access_token_digest_unique": {
+          "name": "issued_credentials_access_token_digest_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "access_token_digest"
+          ]
+        },
+        "issued_credentials_refresh_token_digest_unique": {
+          "name": "issued_credentials_refresh_token_digest_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "refresh_token_digest"
+          ]
+        },
+        "issued_credentials_authorization_code_digest_unique": {
+          "name": "issued_credentials_authorization_code_digest_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "authorization_code_digest"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.addresses": {
+      "name": "addresses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "street": {
+          "name": "street",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "number": {
+          "name": "number",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "neighborhood": {
+          "name": "neighborhood",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "city": {
+          "name": "city",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "zip_code": {
+          "name": "zip_code",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "country": {
+          "name": "country",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "complement": {
+          "name": "complement",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.external_booking_sources": {
+      "name": "external_booking_sources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "property_id": {
+          "name": "property_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform_name": {
+          "name": "platform_name",
+          "type": "calendar_sync_platforms",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sync_url": {
+          "name": "sync_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "external_booking_sources_property_id_properties_id_fk": {
+          "name": "external_booking_sources_property_id_properties_id_fk",
+          "tableFrom": "external_booking_sources",
+          "tableTo": "properties",
+          "columnsFrom": [
+            "property_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.properties": {
+      "name": "properties",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address_id": {
+          "name": "address_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "images": {
+          "name": "images",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "capacity": {
+          "name": "capacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "properties_user_id_users_id_fk": {
+          "name": "properties_user_id_users_id_fk",
+          "tableFrom": "properties",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "properties_address_id_addresses_id_fk": {
+          "name": "properties_address_id_addresses_id_fk",
+          "tableFrom": "properties",
+          "tableTo": "addresses",
+          "columnsFrom": [
+            "address_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.property_settings": {
+      "name": "property_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "property_id": {
+          "name": "property_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "property_settings_property_id_key_idx": {
+          "name": "property_settings_property_id_key_idx",
+          "columns": [
+            {
+              "expression": "property_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"property_settings\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "property_settings_property_id_properties_id_fk": {
+          "name": "property_settings_property_id_properties_id_fk",
+          "tableFrom": "property_settings",
+          "tableTo": "properties",
+          "columnsFrom": [
+            "property_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stays": {
+      "name": "stays",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "property_id": {
+          "name": "property_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "check_in": {
+          "name": "check_in",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "check_out": {
+          "name": "check_out",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guests": {
+          "name": "guests",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entrance_code": {
+          "name": "entrance_code",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price": {
+          "name": "price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'INTERNAL'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "stays_tenant_id_tenants_id_fk": {
+          "name": "stays_tenant_id_tenants_id_fk",
+          "tableFrom": "stays",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "stays_property_id_properties_id_fk": {
+          "name": "stays_property_id_properties_id_fk",
+          "tableFrom": "stays",
+          "tableTo": "properties",
+          "columnsFrom": [
+            "property_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tenants": {
+      "name": "tenants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sex": {
+          "name": "sex",
+          "type": "sex",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tenants_phone_unique": {
+          "name": "tenants_phone_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "phone"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ledger_entries": {
+      "name": "ledger_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "property_id": {
+          "name": "property_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ledger_entries_property_id_properties_id_fk": {
+          "name": "ledger_entries_property_id_properties_id_fk",
+          "tableFrom": "ledger_entries",
+          "tableTo": "properties",
+          "columnsFrom": [
+            "property_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_settings": {
+      "name": "app_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "app_settings_key_unique": {
+          "name": "app_settings_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.calendar_sync_platforms": {
+      "name": "calendar_sync_platforms",
+      "schema": "public",
+      "values": [
+        "AIRBNB",
+        "BOOKING"
+      ]
+    },
+    "public.sex": {
+      "name": "sex",
+      "schema": "public",
+      "values": [
+        "MALE",
+        "FEMALE",
+        "OTHER"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/0005_snapshot.json
+++ b/drizzle/meta/0005_snapshot.json
@@ -1,0 +1,1423 @@
+{
+  "id": "880b2c8d-52ba-4d4f-9811-eaae836238d7",
+  "prevId": "b606ddf9-1243-4a20-8ee0-16976890a127",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password": {
+          "name": "password",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_registrations": {
+      "name": "app_registrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_name": {
+          "name": "client_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_endpoint_auth_method": {
+          "name": "token_endpoint_auth_method",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.authorization_codes": {
+      "name": "authorization_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "code_digest": {
+          "name": "code_digest",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "app_registration_id": {
+          "name": "app_registration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consent_id": {
+          "name": "consent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uri": {
+          "name": "redirect_uri",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_challenge": {
+          "name": "code_challenge",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_challenge_method": {
+          "name": "code_challenge_method",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource": {
+          "name": "resource",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "authorization_codes_app_registration_id_app_registrations_id_fk": {
+          "name": "authorization_codes_app_registration_id_app_registrations_id_fk",
+          "tableFrom": "authorization_codes",
+          "tableTo": "app_registrations",
+          "columnsFrom": [
+            "app_registration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "authorization_codes_consent_id_consents_id_fk": {
+          "name": "authorization_codes_consent_id_consents_id_fk",
+          "tableFrom": "authorization_codes",
+          "tableTo": "consents",
+          "columnsFrom": [
+            "consent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "authorization_codes_code_digest_unique": {
+          "name": "authorization_codes_code_digest_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code_digest"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.authorization_requests": {
+      "name": "authorization_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "identifier_digest": {
+          "name": "identifier_digest",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "app_registration_id": {
+          "name": "app_registration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uri": {
+          "name": "redirect_uri",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_challenge": {
+          "name": "code_challenge",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_challenge_method": {
+          "name": "code_challenge_method",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource": {
+          "name": "resource",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "authorization_requests_app_registration_id_app_registrations_id_fk": {
+          "name": "authorization_requests_app_registration_id_app_registrations_id_fk",
+          "tableFrom": "authorization_requests",
+          "tableTo": "app_registrations",
+          "columnsFrom": [
+            "app_registration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "authorization_requests_identifier_digest_unique": {
+          "name": "authorization_requests_identifier_digest_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "identifier_digest"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.consents": {
+      "name": "consents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "app_registration_id": {
+          "name": "app_registration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "consents_user_id_app_registration_id_idx": {
+          "name": "consents_user_id_app_registration_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "app_registration_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "consents_user_id_users_id_fk": {
+          "name": "consents_user_id_users_id_fk",
+          "tableFrom": "consents",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "consents_app_registration_id_app_registrations_id_fk": {
+          "name": "consents_app_registration_id_app_registrations_id_fk",
+          "tableFrom": "consents",
+          "tableTo": "app_registrations",
+          "columnsFrom": [
+            "app_registration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issued_credentials": {
+      "name": "issued_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consent_id": {
+          "name": "consent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "family_id": {
+          "name": "family_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token_digest": {
+          "name": "access_token_digest",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token_digest": {
+          "name": "refresh_token_digest",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource": {
+          "name": "resource",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "authorization_code_digest": {
+          "name": "authorization_code_digest",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rotated_at": {
+          "name": "rotated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "successor_id": {
+          "name": "successor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "issued_credentials_family_id_idx": {
+          "name": "issued_credentials_family_id_idx",
+          "columns": [
+            {
+              "expression": "family_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issued_credentials_consent_id_consents_id_fk": {
+          "name": "issued_credentials_consent_id_consents_id_fk",
+          "tableFrom": "issued_credentials",
+          "tableTo": "consents",
+          "columnsFrom": [
+            "consent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issued_credentials_successor_id_issued_credentials_id_fk": {
+          "name": "issued_credentials_successor_id_issued_credentials_id_fk",
+          "tableFrom": "issued_credentials",
+          "tableTo": "issued_credentials",
+          "columnsFrom": [
+            "successor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "issued_credentials_access_token_digest_unique": {
+          "name": "issued_credentials_access_token_digest_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "access_token_digest"
+          ]
+        },
+        "issued_credentials_refresh_token_digest_unique": {
+          "name": "issued_credentials_refresh_token_digest_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "refresh_token_digest"
+          ]
+        },
+        "issued_credentials_authorization_code_digest_unique": {
+          "name": "issued_credentials_authorization_code_digest_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "authorization_code_digest"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.addresses": {
+      "name": "addresses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "street": {
+          "name": "street",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "number": {
+          "name": "number",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "neighborhood": {
+          "name": "neighborhood",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "city": {
+          "name": "city",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "zip_code": {
+          "name": "zip_code",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "country": {
+          "name": "country",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "complement": {
+          "name": "complement",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.external_booking_sources": {
+      "name": "external_booking_sources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "property_id": {
+          "name": "property_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform_name": {
+          "name": "platform_name",
+          "type": "calendar_sync_platforms",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sync_url": {
+          "name": "sync_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "external_booking_sources_property_id_properties_id_fk": {
+          "name": "external_booking_sources_property_id_properties_id_fk",
+          "tableFrom": "external_booking_sources",
+          "tableTo": "properties",
+          "columnsFrom": [
+            "property_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.properties": {
+      "name": "properties",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address_id": {
+          "name": "address_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "images": {
+          "name": "images",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "capacity": {
+          "name": "capacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "properties_user_id_users_id_fk": {
+          "name": "properties_user_id_users_id_fk",
+          "tableFrom": "properties",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "properties_address_id_addresses_id_fk": {
+          "name": "properties_address_id_addresses_id_fk",
+          "tableFrom": "properties",
+          "tableTo": "addresses",
+          "columnsFrom": [
+            "address_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.property_settings": {
+      "name": "property_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "property_id": {
+          "name": "property_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "property_settings_property_id_key_idx": {
+          "name": "property_settings_property_id_key_idx",
+          "columns": [
+            {
+              "expression": "property_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"property_settings\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "property_settings_property_id_properties_id_fk": {
+          "name": "property_settings_property_id_properties_id_fk",
+          "tableFrom": "property_settings",
+          "tableTo": "properties",
+          "columnsFrom": [
+            "property_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stays": {
+      "name": "stays",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "property_id": {
+          "name": "property_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "check_in": {
+          "name": "check_in",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "check_out": {
+          "name": "check_out",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guests": {
+          "name": "guests",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entrance_code": {
+          "name": "entrance_code",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price": {
+          "name": "price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'INTERNAL'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "stays_tenant_id_tenants_id_fk": {
+          "name": "stays_tenant_id_tenants_id_fk",
+          "tableFrom": "stays",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "stays_property_id_properties_id_fk": {
+          "name": "stays_property_id_properties_id_fk",
+          "tableFrom": "stays",
+          "tableTo": "properties",
+          "columnsFrom": [
+            "property_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tenants": {
+      "name": "tenants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sex": {
+          "name": "sex",
+          "type": "sex",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tenants_phone_unique": {
+          "name": "tenants_phone_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "phone"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ledger_entries": {
+      "name": "ledger_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "property_id": {
+          "name": "property_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ledger_entries_property_id_properties_id_fk": {
+          "name": "ledger_entries_property_id_properties_id_fk",
+          "tableFrom": "ledger_entries",
+          "tableTo": "properties",
+          "columnsFrom": [
+            "property_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_settings": {
+      "name": "app_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "app_settings_key_unique": {
+          "name": "app_settings_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.calendar_sync_platforms": {
+      "name": "calendar_sync_platforms",
+      "schema": "public",
+      "values": [
+        "AIRBNB",
+        "BOOKING"
+      ]
+    },
+    "public.sex": {
+      "name": "sex",
+      "schema": "public",
+      "values": [
+        "MALE",
+        "FEMALE",
+        "OTHER"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -29,6 +29,20 @@
       "when": 1786229529965,
       "tag": "0003_tired_jocasta",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1786803384711,
+      "tag": "0004_mighty_morg",
+      "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1786813275621,
+      "tag": "0005_absent_squadron_supreme",
+      "breakpoints": true
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "db:push": "drizzle-kit push",
     "db:push:test": "bun --env-file=.env.test x drizzle-kit push",
     "db:migration": "drizzle-kit generate",
-    "db:migrate": "drizzle-kit migrate"
+    "db:migrate": "drizzle-kit migrate",
+    "db:baseline-migrations": "bun run scripts/baseline_drizzle_migrations.ts"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",

--- a/scripts/baseline_drizzle_migrations.ts
+++ b/scripts/baseline_drizzle_migrations.ts
@@ -1,0 +1,100 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { sql } from "drizzle-orm";
+import { db } from "../src/core/infra/database/drizzle/database";
+
+/**
+ * One-time cutover for databases that were provisioned entirely via
+ * `drizzle-kit push` (no migration history) and are switching to
+ * `drizzle-kit migrate` for the first time.
+ *
+ * `drizzle-kit migrate` tracks progress in `drizzle.__drizzle_migrations`
+ * and applies every migration newer than the last recorded one. A database
+ * with no history would replay every migration from `0000` onward,
+ * including `CREATE TABLE` statements for tables that already exist from
+ * prior `push` runs, and fail.
+ *
+ * This script marks `0003_tired_jocasta` — the last migration whose schema
+ * was already applied via `push` before this project switched to
+ * `migrate` — as done, so `migrate` only applies what comes after it. It
+ * is a no-op (does nothing, exits 0) once the tracking table already has
+ * any row, so it is safe to run on every deploy.
+ */
+const BASELINE_TAG = "0003_tired_jocasta";
+const MIGRATIONS_SCHEMA = "drizzle";
+const MIGRATIONS_TABLE = "__drizzle_migrations";
+
+async function main() {
+  const journalPath = path.join(
+    import.meta.dir,
+    "..",
+    "drizzle",
+    "meta",
+    "_journal.json"
+  );
+  const journal = JSON.parse(fs.readFileSync(journalPath, "utf-8")) as {
+    entries: { tag: string; when: number }[];
+  };
+  const baselineEntry = journal.entries.find(e => e.tag === BASELINE_TAG);
+  if (!baselineEntry) {
+    throw new Error(
+      `Baseline migration "${BASELINE_TAG}" not found in ${journalPath}`
+    );
+  }
+
+  const migrationSqlPath = path.join(
+    import.meta.dir,
+    "..",
+    "drizzle",
+    `${BASELINE_TAG}.sql`
+  );
+  const migrationSql = fs.readFileSync(migrationSqlPath, "utf-8");
+  const hash = crypto.createHash("sha256").update(migrationSql).digest("hex");
+
+  const tableExists = await db.execute<{ exists: boolean }>(sql`
+    select exists (
+      select 1 from information_schema.tables
+      where table_schema = ${MIGRATIONS_SCHEMA} and table_name = ${MIGRATIONS_TABLE}
+    ) as "exists"
+  `);
+
+  if (tableExists.rows[0]?.exists) {
+    const existingRows = await db.execute<{ count: number }>(
+      sql.raw(
+        `select count(*)::int as count from ${MIGRATIONS_SCHEMA}.${MIGRATIONS_TABLE}`
+      )
+    );
+    if ((existingRows.rows[0]?.count ?? 0) > 0) {
+      console.log(
+        "[baseline] Migrations table already has history — nothing to do."
+      );
+      return;
+    }
+  }
+
+  await db.execute(sql.raw(`create schema if not exists ${MIGRATIONS_SCHEMA}`));
+  await db.execute(
+    sql.raw(`
+      create table if not exists ${MIGRATIONS_SCHEMA}.${MIGRATIONS_TABLE} (
+        id serial primary key,
+        hash text not null,
+        created_at bigint
+      )
+    `)
+  );
+  await db.execute(
+    sql`insert into ${sql.identifier(MIGRATIONS_SCHEMA)}.${sql.identifier(MIGRATIONS_TABLE)} ("hash", "created_at") values (${hash}, ${baselineEntry.when})`
+  );
+
+  console.log(
+    `[baseline] Marked "${BASELINE_TAG}" as applied. "drizzle-kit migrate" will only run migrations after it.`
+  );
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch(error => {
+    console.error("[baseline] Failed:", error);
+    process.exit(1);
+  });

--- a/src/auth/domain/service/oauth_scope_policy.ts
+++ b/src/auth/domain/service/oauth_scope_policy.ts
@@ -30,7 +30,7 @@ export function defaultScope(): string {
 
 const SCOPE_DESCRIPTIONS: Readonly<Record<string, string>> = {
   [OAUTH_MCP_SCOPE]:
-    "Book and cancel stays, record expenses, and view your properties and stays on your behalf. Cancelling a stay is irreversible.",
+    "Book and cancel stays, record expenses, view your properties and stays, and read, change, and remove your properties' configuration settings on your behalf. Cancelling a stay and removing a configuration setting's value are both irreversible.",
 };
 
 /**

--- a/src/auth/infra/database/postgres_repository/auth_postgres_repository.ts
+++ b/src/auth/infra/database/postgres_repository/auth_postgres_repository.ts
@@ -11,6 +11,7 @@ import {
   propertiesTable,
   addressesTable,
   externalBookingSources,
+  propertySettingsTable,
 } from "../../../../core/infra/database/drizzle/schema";
 
 type UserRow = typeof usersTable.$inferSelect;
@@ -70,26 +71,37 @@ export class AuthPostgresRepository implements AuthRepository {
   }
 
   async purgeUserData(userId: string): Promise<void> {
-    const properties = await db.query.propertiesTable.findMany({
-      where: eq(propertiesTable.user_id, userId),
-      columns: { id: true, address_id: true },
+    await db.transaction(async tx => {
+      const properties = await tx.query.propertiesTable.findMany({
+        where: eq(propertiesTable.user_id, userId),
+        columns: { id: true, address_id: true },
+      });
+
+      const propertyIds = properties.map(p => p.id);
+      const addressIds = properties.map(p => p.address_id);
+
+      if (propertyIds.length > 0) {
+        // Both `property_settings` and `external_booking_sources` reference
+        // `properties` with `ON DELETE no action`, so they must be purged
+        // explicitly before `users` is deleted — otherwise the cascade from
+        // `properties.user_id` (ON DELETE cascade) fails midway, leaving the
+        // account partially destroyed.
+        await tx
+          .delete(propertySettingsTable)
+          .where(inArray(propertySettingsTable.property_id, propertyIds));
+
+        await tx
+          .delete(externalBookingSources)
+          .where(inArray(externalBookingSources.property_id, propertyIds));
+      }
+
+      await tx.delete(usersTable).where(eq(usersTable.id, userId));
+
+      if (addressIds.length > 0) {
+        await tx
+          .delete(addressesTable)
+          .where(inArray(addressesTable.id, addressIds));
+      }
     });
-
-    const propertyIds = properties.map(p => p.id);
-    const addressIds = properties.map(p => p.address_id);
-
-    if (propertyIds.length > 0) {
-      await db
-        .delete(externalBookingSources)
-        .where(inArray(externalBookingSources.property_id, propertyIds));
-    }
-
-    await db.delete(usersTable).where(eq(usersTable.id, userId));
-
-    if (addressIds.length > 0) {
-      await db
-        .delete(addressesTable)
-        .where(inArray(addressesTable.id, addressIds));
-    }
   }
 }

--- a/src/backoffice/domain/entity/app_setting.ts
+++ b/src/backoffice/domain/entity/app_setting.ts
@@ -4,6 +4,14 @@ import {
   type WithoutBaseEntity,
 } from "../../../core/domain/entity/base_entity";
 import { ValidationError } from "../../../core/application/error/validation_error";
+import {
+  boundedJsonValue,
+  refineSettingValueForType,
+  settingDescriptionSchema,
+  settingKeySchema,
+  settingTypeSchema,
+  type SettingType,
+} from "../../../core/domain/value_object/setting_value";
 
 /**
  * Security invariant: AppSetting must NOT store secrets, credentials, or PII.
@@ -11,120 +19,26 @@ import { ValidationError } from "../../../core/application/error/validation_erro
  * only. Sensitive values must be managed via environment variables or a secrets manager.
  */
 
-// ---------------------------------------------------------------------------
-// boundedJsonValue — reusable refinement for the `value` field
-// Rejects: JSON > 16 KB, depth > 5, objects with > 50 root keys.
-// ---------------------------------------------------------------------------
+export { boundedJsonValue };
 
-function measureDepth(val: unknown, current = 0): number {
-  if (current > 5) return current;
-  if (Array.isArray(val))
-    return Math.max(...val.map(item => measureDepth(item, current + 1)));
-  if (val !== null && typeof val === "object") {
-    const values = Object.values(val as object);
-    if (values.length === 0) return current;
-    return Math.max(...values.map(v => measureDepth(v, current + 1)));
-  }
-  return current;
-}
+export const appSettingTypeSchema = settingTypeSchema;
 
-export const boundedJsonValue = z.unknown().superRefine((val, ctx) => {
-  if (val === undefined) {
-    ctx.addIssue({
-      code: z.ZodIssueCode.custom,
-      message: "Value is required",
-    });
-    return;
-  }
-  const json = JSON.stringify(val);
-  if (json.length > 16384) {
-    ctx.addIssue({
-      code: z.ZodIssueCode.custom,
-      message: "Value exceeds maximum allowed size of 16 KB",
-    });
-    return;
-  }
-  if (measureDepth(val) > 5) {
-    ctx.addIssue({
-      code: z.ZodIssueCode.custom,
-      message: "Value exceeds maximum nesting depth of 5",
-    });
-    return;
-  }
-  if (
-    val !== null &&
-    typeof val === "object" &&
-    !Array.isArray(val) &&
-    Object.keys(val as object).length > 50
-  ) {
-    ctx.addIssue({
-      code: z.ZodIssueCode.custom,
-      message: "Object value must not have more than 50 root keys",
-    });
-  }
-});
-
-export const appSettingTypeSchema = z.enum([
-  "string",
-  "number",
-  "boolean",
-  "json",
-]);
-
-export type AppSettingType = z.infer<typeof appSettingTypeSchema>;
+export type AppSettingType = SettingType;
 
 export const appSettingSchema = baseEntitySchema
   .extend({
-    key: z
-      .string()
-      .min(1)
-      .max(255)
-      .regex(
-        /^[a-z0-9_.-]+$/,
-        "Key must contain only lowercase letters, digits, underscores, dots and hyphens"
-      ),
+    key: settingKeySchema,
     value: boundedJsonValue,
     type: appSettingTypeSchema,
-    description: z.string().max(500).nullable().optional().default(null),
+    description: settingDescriptionSchema,
   })
-  .superRefine((data, ctx) => {
-    const { type, value } = data;
-    if (type === "string" && typeof value !== "string") {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: "Invalid value for type string",
-        path: ["value"],
-      });
-    } else if (type === "number") {
-      if (typeof value !== "number" || !Number.isFinite(value)) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          message: "Invalid value for type number",
-          path: ["value"],
-        });
-      }
-    } else if (type === "boolean" && typeof value !== "boolean") {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: "Invalid value for type boolean",
-        path: ["value"],
-      });
-    } else if (type === "json") {
-      if (value === null || typeof value !== "object") {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          message: "Invalid value for type json",
-          path: ["value"],
-        });
-      }
-    }
-  });
+  .superRefine((data, ctx) => refineSettingValueForType(data, ctx));
 
 export type AppSettingData = z.infer<typeof appSettingSchema>;
 
 /**
  * @kind Entity, Aggregate Root
- * @bc settings
+ * @bc backoffice
  *
  * Security note: do NOT store secrets, credentials, or PII in this entity.
  */

--- a/src/core/domain/value_object/setting_value.ts
+++ b/src/core/domain/value_object/setting_value.ts
@@ -1,0 +1,184 @@
+import { z } from "zod";
+
+/**
+ * Shared "typed configuration value" building blocks, consumed by every
+ * bounded context that models a generic key/value setting (`AppSetting` in
+ * `backoffice`, `PropertySetting` in `property_management`). Each BC keeps
+ * its own entity, repository, use cases and controllers — only the value
+ * validation (type enum, key format, bounded JSON, type/value coherence) is
+ * shared here to avoid duplicating it across bounded contexts.
+ */
+
+// ---------------------------------------------------------------------------
+// boundedJsonValue — reusable refinement for a setting's `value` field.
+// Rejects: JSON > 16 KB, depth > 5, objects with > 50 root keys.
+// ---------------------------------------------------------------------------
+
+function measureDepth(val: unknown, current = 0): number {
+  if (current > 5) return current;
+  if (Array.isArray(val))
+    return Math.max(...val.map(item => measureDepth(item, current + 1)));
+  if (val !== null && typeof val === "object") {
+    const values = Object.values(val as object);
+    if (values.length === 0) return current;
+    return Math.max(...values.map(v => measureDepth(v, current + 1)));
+  }
+  return current;
+}
+
+// Null byte + C0/DEL control characters — rejected anywhere in a value
+// (string leaves and, for JSON objects, keys too), since a setting is
+// consumed downstream as display text/JSON and must never carry bytes that
+// break rendering, logging, or storage encoding.
+const CONTROL_CHARACTER_PATTERN = /[\x00-\x1F\x7F]/;
+
+function hasControlCharacters(val: unknown): boolean {
+  if (typeof val === "string") {
+    return CONTROL_CHARACTER_PATTERN.test(val);
+  }
+  if (Array.isArray(val)) {
+    return val.some(hasControlCharacters);
+  }
+  if (val !== null && typeof val === "object") {
+    return Object.entries(val as object).some(
+      ([key, value]) =>
+        CONTROL_CHARACTER_PATTERN.test(key) || hasControlCharacters(value)
+    );
+  }
+  return false;
+}
+
+export const boundedJsonValue = z.unknown().superRefine((val, ctx) => {
+  if (val === undefined) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "Value is required",
+    });
+    return;
+  }
+  if (hasControlCharacters(val)) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "Value must not contain null bytes or control characters",
+    });
+    return;
+  }
+  const json = JSON.stringify(val);
+  if (json.length > 16384) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "Value exceeds maximum allowed size of 16 KB",
+    });
+    return;
+  }
+  if (measureDepth(val) > 5) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "Value exceeds maximum nesting depth of 5",
+    });
+    return;
+  }
+  if (
+    val !== null &&
+    typeof val === "object" &&
+    !Array.isArray(val) &&
+    Object.keys(val as object).length > 50
+  ) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "Object value must not have more than 50 root keys",
+    });
+  }
+});
+
+export const settingTypeSchema = z.enum([
+  "string",
+  "number",
+  "boolean",
+  "json",
+]);
+
+export type SettingType = z.infer<typeof settingTypeSchema>;
+
+/**
+ * Heuristic denylist: neither `AppSetting` nor `PropertySetting` is a
+ * secrets manager (see each entity's docstring), but nothing technical
+ * stopped a caller from naming a key `api_key` or `smart_lock_pin` and
+ * stashing a real credential in `value` before this. Matching key names are
+ * rejected outright — a caller storing an actual secret under an innocuous
+ * key is a separate, unenforceable problem, but this at least closes the
+ * obvious path.
+ */
+const SUSPICIOUS_SETTING_KEY_PATTERN =
+  /(secret|token|password|api_key|pin|code|credential)/i;
+
+export const settingKeySchema = z
+  .string()
+  .min(1)
+  .max(255)
+  .regex(
+    /^[a-z0-9_.-]+$/,
+    "Key must contain only lowercase letters, digits, underscores, dots and hyphens"
+  )
+  .refine(key => !SUSPICIOUS_SETTING_KEY_PATTERN.test(key), {
+    message:
+      "Key looks like it stores a secret or credential (matches secret/token/password/api_key/pin/code/credential); this is a generic configuration store, not a secrets manager — use a dedicated secrets manager instead",
+  });
+
+/**
+ * Shared `description` field for both `AppSetting` and `PropertySetting`:
+ * bounded length plus the same null byte/control character rejection as
+ * `boundedJsonValue`, since `description` is free text rendered/logged the
+ * same way a string `value` is.
+ */
+export const settingDescriptionSchema = z
+  .string()
+  .max(500)
+  .refine(description => !CONTROL_CHARACTER_PATTERN.test(description), {
+    message: "Description must not contain null bytes or control characters",
+  })
+  .nullable()
+  .optional()
+  .default(null);
+
+/**
+ * Validates that `value` matches the shape implied by `type`, adding a Zod
+ * issue on the `value` path when it doesn't. Meant to be called from within
+ * a `.superRefine()` on the entity's own schema, so each entity keeps its
+ * own error message wiring while sharing the coherence rules.
+ */
+export function refineSettingValueForType(
+  data: { type: SettingType; value: unknown },
+  ctx: z.RefinementCtx
+): void {
+  const { type, value } = data;
+  if (type === "string" && typeof value !== "string") {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "Invalid value for type string",
+      path: ["value"],
+    });
+  } else if (type === "number") {
+    if (typeof value !== "number" || !Number.isFinite(value)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "Invalid value for type number",
+        path: ["value"],
+      });
+    }
+  } else if (type === "boolean" && typeof value !== "boolean") {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "Invalid value for type boolean",
+      path: ["value"],
+    });
+  } else if (type === "json") {
+    if (value === null || typeof value !== "object") {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "Invalid value for type json",
+        path: ["value"],
+      });
+    }
+  }
+}

--- a/src/core/infra/database/drizzle/schemas/property_schemas.ts
+++ b/src/core/infra/database/drizzle/schemas/property_schemas.ts
@@ -1,6 +1,15 @@
-import { pgEnum, pgTable, varchar, uuid, integer, text } from "drizzle-orm/pg-core";
+import {
+  pgEnum,
+  pgTable,
+  varchar,
+  uuid,
+  integer,
+  text,
+  jsonb,
+  uniqueIndex,
+} from "drizzle-orm/pg-core";
 import { baseSchema } from "./base_schema";
-import { relations } from "drizzle-orm";
+import { relations, isNull } from "drizzle-orm";
 import { usersTable } from "./auth_schemas";
 import { staysTable } from "./stay_schemas";
 
@@ -74,6 +83,44 @@ export const externalBookingSourcesRelations = relations(
   ({ one }) => ({
     property: one(propertiesTable, {
       fields: [externalBookingSources.property_id],
+      references: [propertiesTable.id],
+    }),
+  }),
+);
+
+export const propertySettingsTable = pgTable(
+  "property_settings",
+  {
+    ...baseSchema,
+    property_id: uuid()
+      .references(() => propertiesTable.id)
+      .notNull(),
+    key: varchar({ length: 255 }).notNull(),
+    // Nullable: a soft-deleted setting has its value redacted to `null` (see
+    // `PropertySetting.softDelete()`) rather than retaining its content
+    // indefinitely.
+    value: jsonb(),
+    type: varchar({ length: 20 }).notNull(),
+    description: varchar({ length: 500 }),
+  },
+  table => [
+    /**
+     * Unlike `app_settings`' global `UNIQUE(key)`, uniqueness here is scoped
+     * to `(property_id, key)` and restricted to non-deleted rows via a
+     * partial index — a soft-deleted setting must not block recreating the
+     * same key on the same property.
+     */
+    uniqueIndex("property_settings_property_id_key_idx")
+      .on(table.property_id, table.key)
+      .where(isNull(table.deleted_at)),
+  ],
+);
+
+export const propertySettingsRelations = relations(
+  propertySettingsTable,
+  ({ one }) => ({
+    property: one(propertiesTable, {
+      fields: [propertySettingsTable.property_id],
       references: [propertiesTable.id],
     }),
   }),

--- a/src/core/infra/http/routes/routes.ts
+++ b/src/core/infra/http/routes/routes.ts
@@ -90,6 +90,26 @@ const propertyManagementControllers: Route[] = [
     authenticated: true,
     controller: propertyManagementDi.makeFindPropertyController(),
   },
+  {
+    authenticated: true,
+    controller: propertyManagementDi.makeCreatePropertySettingController(),
+  },
+  {
+    authenticated: true,
+    controller: propertyManagementDi.makeListPropertySettingsController(),
+  },
+  {
+    authenticated: true,
+    controller: propertyManagementDi.makeGetPropertySettingController(),
+  },
+  {
+    authenticated: true,
+    controller: propertyManagementDi.makeUpdatePropertySettingController(),
+  },
+  {
+    authenticated: true,
+    controller: propertyManagementDi.makeDeletePropertySettingController(),
+  },
 ];
 
 const stayControllers: Route[] = [

--- a/src/core/infra/mcp/routes.ts
+++ b/src/core/infra/mcp/routes.ts
@@ -17,9 +17,14 @@ import type { McpToolDefinition } from "./mcp_tool";
 import {
   makeBookStayTool,
   makeCancelStayTool,
+  makeCreatePropertySettingTool,
+  makeDeletePropertySettingTool,
+  makeGetPropertySettingTool,
   makeListPropertiesTool,
+  makeListPropertySettingsTool,
   makeListStaysTool,
   makeRecordExpenseTool,
+  makeUpdatePropertySettingTool,
 } from "./tools";
 
 const MCP_SERVER_NAME = "stayhub";
@@ -108,6 +113,11 @@ export function makeMcpRequestHandler(
     makeRecordExpenseTool(dependencies.financeDi),
     makeBookStayTool(dependencies.propertyDi),
     makeCancelStayTool(dependencies.stayDi),
+    makeListPropertySettingsTool(dependencies.propertyManagementDi),
+    makeGetPropertySettingTool(dependencies.propertyManagementDi),
+    makeCreatePropertySettingTool(dependencies.propertyManagementDi),
+    makeUpdatePropertySettingTool(dependencies.propertyManagementDi),
+    makeDeletePropertySettingTool(dependencies.propertyManagementDi),
   ];
 
   return async function handleMcpRequest(request: Request): Promise<Response> {

--- a/src/core/infra/mcp/tools/create_property_setting.ts
+++ b/src/core/infra/mcp/tools/create_property_setting.ts
@@ -1,0 +1,66 @@
+import { z } from "zod";
+import type { PropertyManagementDi } from "../../../../property_management/infra/di/property_management_di";
+import {
+  boundedJsonValue,
+  settingKeySchema,
+  settingTypeSchema,
+} from "../../../domain/value_object/setting_value";
+import type { McpToolDefinition } from "../mcp_tool";
+
+const inputSchema = {
+  property_id: z
+    .uuid()
+    .describe(
+      "ID of the property the setting should be created for. Must be a property administered by the authenticated user."
+    ),
+  key: settingKeySchema.describe(
+    "Unique key for this setting within the property. Lowercase letters, digits, underscores, dots and hyphens only. Must not look like a secret/credential name (e.g. token, password, api_key, pin) — this is a generic configuration store, not a secrets manager."
+  ),
+  value: boundedJsonValue.describe(
+    "Value for this setting. Must match the shape implied by `type` (string, number, boolean, or a JSON object)."
+  ),
+  type: settingTypeSchema.describe(
+    `Type of the value. Must be one of: ${settingTypeSchema.options.join(", ")}.`
+  ),
+  description: z
+    .string()
+    .max(500)
+    .optional()
+    .describe("Optional free-text description of the setting."),
+};
+
+/**
+ * Wires the existing `CreatePropertySettingUseCase` (already used by the
+ * `POST /property/:property_id/settings` HTTP route) as a write MCP tool.
+ * Property ownership validation and the key-uniqueness/active-setting-limit
+ * checks are already handled by the use case — this tool does not duplicate
+ * them.
+ */
+export function makeCreatePropertySettingTool(
+  propertyManagementDi: PropertyManagementDi
+): McpToolDefinition<typeof inputSchema> {
+  const useCase = propertyManagementDi.makeCreatePropertySettingUseCase();
+
+  return {
+    name: "create_property_setting",
+    description: "Creates a new configuration entry scoped to a property.",
+    inputSchema,
+    annotations: {
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+    },
+    handler: async (input, user) => {
+      return useCase.execute(
+        {
+          property_id: input.property_id,
+          key: input.key,
+          value: input.value,
+          type: input.type,
+          description: input.description ?? null,
+        },
+        user
+      );
+    },
+  };
+}

--- a/src/core/infra/mcp/tools/delete_property_setting.ts
+++ b/src/core/infra/mcp/tools/delete_property_setting.ts
@@ -1,0 +1,48 @@
+import { z } from "zod";
+import type { PropertyManagementDi } from "../../../../property_management/infra/di/property_management_di";
+import type { McpToolDefinition } from "../mcp_tool";
+
+const inputSchema = {
+  property_id: z
+    .uuid()
+    .describe(
+      "ID of the property the setting belongs to. Must be a property administered by the authenticated user."
+    ),
+  id: z
+    .uuid()
+    .describe(
+      "ID of the property setting to delete. Must belong to the given property. Can be obtained via list_property_settings."
+    ),
+};
+
+/**
+ * Wires the existing `DeletePropertySettingUseCase` (already used by the
+ * `DELETE /property/:property_id/settings/:id` HTTP route) as a destructive
+ * MCP tool. Property ownership validation is already handled by the use case
+ * via `PropertyOwnershipPolicy` — this tool does not duplicate it.
+ */
+export function makeDeletePropertySettingTool(
+  propertyManagementDi: PropertyManagementDi
+): McpToolDefinition<typeof inputSchema> {
+  const useCase = propertyManagementDi.makeDeletePropertySettingUseCase();
+
+  return {
+    name: "delete_property_setting",
+    description:
+      "Deletes a property-scoped configuration entry. This is a soft delete: the row is kept, but its value and description are permanently erased and cannot be recovered — this is not a reversible action, there is no undo.",
+    inputSchema,
+    annotations: {
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: false,
+    },
+    handler: async (input, user) => {
+      await useCase.execute(
+        { property_id: input.property_id, id: input.id },
+        user
+      );
+
+      return { success: true };
+    },
+  };
+}

--- a/src/core/infra/mcp/tools/get_property_setting.ts
+++ b/src/core/infra/mcp/tools/get_property_setting.ts
@@ -1,0 +1,44 @@
+import { z } from "zod";
+import type { PropertyManagementDi } from "../../../../property_management/infra/di/property_management_di";
+import type { McpToolDefinition } from "../mcp_tool";
+
+const inputSchema = {
+  property_id: z
+    .uuid()
+    .describe(
+      "ID of the property the setting belongs to. Must be a property administered by the authenticated user."
+    ),
+  id: z
+    .uuid()
+    .describe(
+      "ID of the property setting to fetch. Must belong to the given property. Can be obtained via list_property_settings."
+    ),
+};
+
+/**
+ * Wires the existing `GetPropertySettingUseCase` (already used by the
+ * `GET /property/:property_id/settings/:id` HTTP route) as a read-only MCP
+ * tool. Property ownership validation is already handled by the use case via
+ * `PropertyOwnershipPolicy` — this tool does not duplicate it.
+ */
+export function makeGetPropertySettingTool(
+  propertyManagementDi: PropertyManagementDi
+): McpToolDefinition<typeof inputSchema> {
+  const useCase = propertyManagementDi.makeGetPropertySettingUseCase();
+
+  return {
+    name: "get_property_setting",
+    description:
+      "Fetches a single configuration entry scoped to a property by its ID.",
+    inputSchema,
+    annotations: {
+      readOnlyHint: true,
+    },
+    handler: async (input, user) => {
+      return useCase.execute(
+        { property_id: input.property_id, id: input.id },
+        user
+      );
+    },
+  };
+}

--- a/src/core/infra/mcp/tools/index.ts
+++ b/src/core/infra/mcp/tools/index.ts
@@ -1,5 +1,10 @@
 export { makeBookStayTool } from "./book_stay";
 export { makeCancelStayTool } from "./cancel_stay";
+export { makeCreatePropertySettingTool } from "./create_property_setting";
+export { makeDeletePropertySettingTool } from "./delete_property_setting";
+export { makeGetPropertySettingTool } from "./get_property_setting";
 export { makeListPropertiesTool } from "./list_properties";
+export { makeListPropertySettingsTool } from "./list_property_settings";
 export { makeListStaysTool } from "./list_stays";
 export { makeRecordExpenseTool } from "./record_expense";
+export { makeUpdatePropertySettingTool } from "./update_property_setting";

--- a/src/core/infra/mcp/tools/list_property_settings.ts
+++ b/src/core/infra/mcp/tools/list_property_settings.ts
@@ -1,0 +1,66 @@
+import { z } from "zod";
+import {
+  DEFAULT_LIMIT,
+  DEFAULT_PAGE,
+  MAX_LIMIT,
+} from "../../../application/dto/pagination";
+import type { PropertyManagementDi } from "../../../../property_management/infra/di/property_management_di";
+import type { McpToolDefinition } from "../mcp_tool";
+
+const inputSchema = {
+  property_id: z
+    .uuid()
+    .describe(
+      "ID of the property whose settings should be listed. Must be a property administered by the authenticated user."
+    ),
+  page: z.coerce
+    .number()
+    .int()
+    .positive()
+    .default(DEFAULT_PAGE)
+    .describe("Page number to retrieve, starting at 1."),
+  limit: z.coerce
+    .number()
+    .int()
+    .positive()
+    .max(MAX_LIMIT)
+    .default(DEFAULT_LIMIT)
+    .describe(`Number of settings per page, up to ${MAX_LIMIT}.`),
+};
+
+/**
+ * Wires the existing `ListPropertySettingsUseCase` (already used by the
+ * `GET /property/:property_id/settings` HTTP route) as a read-only MCP tool.
+ * Property ownership validation is already handled by the use case via
+ * `PropertyOwnershipPolicy` — this tool does not duplicate it.
+ *
+ * The result is paginated (20 per page by default, 100 max). Before
+ * concluding a given key does not exist for a property, page through the
+ * full result set using `page`/`limit` and check `pagination.has_next` —
+ * stopping at the first page and reporting a key as absent is a false
+ * negative if the property has more than one page of settings.
+ */
+export function makeListPropertySettingsTool(
+  propertyManagementDi: PropertyManagementDi
+): McpToolDefinition<typeof inputSchema> {
+  const useCase = propertyManagementDi.makeListPropertySettingsUseCase();
+
+  return {
+    name: "list_property_settings",
+    description:
+      "Lists the configuration entries scoped to a property, paginated. To check whether a given key exists, page through all results (using page/limit and pagination.has_next) before concluding it does not — a single page may not contain every setting.",
+    inputSchema,
+    annotations: {
+      readOnlyHint: true,
+    },
+    handler: async (input, user) => {
+      return useCase.execute(
+        {
+          property_id: input.property_id,
+          pagination: { page: input.page, limit: input.limit },
+        },
+        user
+      );
+    },
+  };
+}

--- a/src/core/infra/mcp/tools/update_property_setting.ts
+++ b/src/core/infra/mcp/tools/update_property_setting.ts
@@ -1,0 +1,76 @@
+import { z } from "zod";
+import type { PropertyManagementDi } from "../../../../property_management/infra/di/property_management_di";
+import {
+  boundedJsonValue,
+  settingTypeSchema,
+} from "../../../domain/value_object/setting_value";
+import type { McpToolDefinition } from "../mcp_tool";
+
+const inputSchema = {
+  property_id: z
+    .uuid()
+    .describe(
+      "ID of the property the setting belongs to. Must be a property administered by the authenticated user."
+    ),
+  id: z
+    .uuid()
+    .describe(
+      "ID of the property setting to update. Must belong to the given property. Can be obtained via list_property_settings. The setting's key is immutable and cannot be changed."
+    ),
+  value: boundedJsonValue
+    .optional()
+    .describe(
+      "New value for this setting. Must match the shape implied by `type` (the new one if provided, otherwise the existing one). Omit to leave the value unchanged."
+    ),
+  type: settingTypeSchema
+    .optional()
+    .describe(
+      `New type for the value. Must be one of: ${settingTypeSchema.options.join(", ")}. Omit to leave the type unchanged.`
+    ),
+  description: z
+    .string()
+    .max(500)
+    .nullable()
+    .optional()
+    .describe(
+      "New free-text description. Pass null to clear it, or omit to leave it unchanged."
+    ),
+};
+
+/**
+ * Wires the existing `UpdatePropertySettingUseCase` (already used by the
+ * `PUT /property/:property_id/settings/:id` HTTP route) as a write MCP tool.
+ * Property ownership validation is already handled by the use case via
+ * `PropertyOwnershipPolicy` — this tool does not duplicate it. Applying the
+ * same value again produces the same resulting state, so this tool is
+ * idempotent.
+ */
+export function makeUpdatePropertySettingTool(
+  propertyManagementDi: PropertyManagementDi
+): McpToolDefinition<typeof inputSchema> {
+  const useCase = propertyManagementDi.makeUpdatePropertySettingUseCase();
+
+  return {
+    name: "update_property_setting",
+    description:
+      "Partially updates a property-scoped configuration entry. The key is immutable.",
+    inputSchema,
+    annotations: {
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: true,
+    },
+    handler: async (input, user) => {
+      return useCase.execute(
+        {
+          property_id: input.property_id,
+          id: input.id,
+          value: input.value,
+          type: input.type,
+          description: input.description,
+        },
+        user
+      );
+    },
+  };
+}

--- a/src/property_management/application/use_case/create_property_setting.ts
+++ b/src/property_management/application/use_case/create_property_setting.ts
@@ -1,0 +1,77 @@
+import { ConflictError } from "../../../core/application/error/conflict_error";
+import type { UseCase } from "../../../core/application/use_case/use_case";
+import type { User } from "../../../auth/domain/entity/user";
+import {
+  PropertySetting,
+  type PropertySettingType,
+} from "../../domain/entity/property_setting";
+import type { PropertySettingRepository } from "../../domain/repository/property_setting_repository";
+import type { PropertyRepository } from "../../domain/repository/property_repository";
+import { PropertyOwnershipPolicy } from "../../domain/policy/property_ownership_policy";
+
+export const MAX_ACTIVE_PROPERTY_SETTINGS = 100;
+
+type Input = {
+  property_id: string;
+  key: string;
+  value: unknown;
+  type: PropertySettingType;
+  description?: string | null;
+};
+
+type Output = {
+  id: string;
+  property_id: string;
+  key: string;
+  value: unknown;
+  type: PropertySettingType;
+  description: string | null;
+  created_at: Date;
+  updated_at: Date;
+};
+
+export class CreatePropertySettingUseCase implements UseCase<Input, Output> {
+  constructor(
+    private readonly propertyRepository: PropertyRepository,
+    private readonly propertySettingRepository: PropertySettingRepository
+  ) {}
+
+  async execute(input: Input, user: User): Promise<Output> {
+    const property = await this.propertyRepository.propertyOfId(
+      input.property_id
+    );
+    PropertyOwnershipPolicy.ensureOwnership(property, user);
+
+    const existing = await this.propertySettingRepository.findByKey(
+      input.key,
+      input.property_id
+    );
+    if (existing) {
+      throw new ConflictError("Property setting key already exists");
+    }
+
+    const setting = PropertySetting.create({
+      property_id: input.property_id,
+      key: input.key,
+      value: input.value,
+      type: input.type,
+      description: input.description ?? null,
+    });
+
+    await this.propertySettingRepository.save(
+      setting,
+      MAX_ACTIVE_PROPERTY_SETTINGS
+    );
+
+    return {
+      id: setting.id,
+      property_id: setting.property_id,
+      key: setting.key,
+      value: setting.value,
+      type: setting.type,
+      description: setting.description,
+      created_at: setting.created_at,
+      updated_at: setting.updated_at,
+    };
+  }
+}

--- a/src/property_management/application/use_case/delete_property_setting.ts
+++ b/src/property_management/application/use_case/delete_property_setting.ts
@@ -1,0 +1,35 @@
+import { ResourceNotFoundError } from "../../../core/application/error/resource_not_found_error";
+import type { UseCase } from "../../../core/application/use_case/use_case";
+import type { User } from "../../../auth/domain/entity/user";
+import type { PropertySettingRepository } from "../../domain/repository/property_setting_repository";
+import type { PropertyRepository } from "../../domain/repository/property_repository";
+import { PropertyOwnershipPolicy } from "../../domain/policy/property_ownership_policy";
+
+type Input = {
+  property_id: string;
+  id: string;
+};
+
+type Output = void;
+
+export class DeletePropertySettingUseCase implements UseCase<Input, Output> {
+  constructor(
+    private readonly propertyRepository: PropertyRepository,
+    private readonly propertySettingRepository: PropertySettingRepository
+  ) {}
+
+  async execute(input: Input, user: User): Promise<Output> {
+    const property = await this.propertyRepository.propertyOfId(
+      input.property_id
+    );
+    PropertyOwnershipPolicy.ensureOwnership(property, user);
+
+    const existing = await this.propertySettingRepository.findById(input.id);
+    if (!existing || existing.property_id !== input.property_id) {
+      throw new ResourceNotFoundError("Property setting");
+    }
+
+    const deleted = existing.softDelete();
+    await this.propertySettingRepository.delete(deleted);
+  }
+}

--- a/src/property_management/application/use_case/get_property_setting.ts
+++ b/src/property_management/application/use_case/get_property_setting.ts
@@ -1,0 +1,53 @@
+import { ResourceNotFoundError } from "../../../core/application/error/resource_not_found_error";
+import type { UseCase } from "../../../core/application/use_case/use_case";
+import type { User } from "../../../auth/domain/entity/user";
+import type { PropertySettingType } from "../../domain/entity/property_setting";
+import type { PropertySettingRepository } from "../../domain/repository/property_setting_repository";
+import type { PropertyRepository } from "../../domain/repository/property_repository";
+import { PropertyOwnershipPolicy } from "../../domain/policy/property_ownership_policy";
+
+type Input = {
+  property_id: string;
+  id: string;
+};
+
+type Output = {
+  id: string;
+  property_id: string;
+  key: string;
+  value: unknown;
+  type: PropertySettingType;
+  description: string | null;
+  created_at: Date;
+  updated_at: Date;
+};
+
+export class GetPropertySettingUseCase implements UseCase<Input, Output> {
+  constructor(
+    private readonly propertyRepository: PropertyRepository,
+    private readonly propertySettingRepository: PropertySettingRepository
+  ) {}
+
+  async execute(input: Input, user: User): Promise<Output> {
+    const property = await this.propertyRepository.propertyOfId(
+      input.property_id
+    );
+    PropertyOwnershipPolicy.ensureOwnership(property, user);
+
+    const setting = await this.propertySettingRepository.findById(input.id);
+    if (!setting || setting.property_id !== input.property_id) {
+      throw new ResourceNotFoundError("Property setting");
+    }
+
+    return {
+      id: setting.id,
+      property_id: setting.property_id,
+      key: setting.key,
+      value: setting.value,
+      type: setting.type,
+      description: setting.description,
+      created_at: setting.created_at,
+      updated_at: setting.updated_at,
+    };
+  }
+}

--- a/src/property_management/application/use_case/list_property_settings.ts
+++ b/src/property_management/application/use_case/list_property_settings.ts
@@ -1,0 +1,61 @@
+import type { UseCase } from "../../../core/application/use_case/use_case";
+import type {
+  PaginatedResult,
+  PaginationInput,
+} from "../../../core/application/dto/pagination";
+import type { User } from "../../../auth/domain/entity/user";
+import type { PropertySettingType } from "../../domain/entity/property_setting";
+import type { PropertySettingRepository } from "../../domain/repository/property_setting_repository";
+import type { PropertyRepository } from "../../domain/repository/property_repository";
+import { PropertyOwnershipPolicy } from "../../domain/policy/property_ownership_policy";
+
+type Input = {
+  property_id: string;
+  pagination: PaginationInput;
+};
+
+type PropertySettingDto = {
+  id: string;
+  property_id: string;
+  key: string;
+  value: unknown;
+  type: PropertySettingType;
+  description: string | null;
+  created_at: Date;
+  updated_at: Date;
+};
+
+type Output = PaginatedResult<PropertySettingDto>;
+
+export class ListPropertySettingsUseCase implements UseCase<Input, Output> {
+  constructor(
+    private readonly propertyRepository: PropertyRepository,
+    private readonly propertySettingRepository: PropertySettingRepository
+  ) {}
+
+  async execute(input: Input, user: User): Promise<Output> {
+    const property = await this.propertyRepository.propertyOfId(
+      input.property_id
+    );
+    PropertyOwnershipPolicy.ensureOwnership(property, user);
+
+    const result = await this.propertySettingRepository.list(
+      input.property_id,
+      input.pagination
+    );
+
+    return {
+      data: result.data.map(setting => ({
+        id: setting.id,
+        property_id: setting.property_id,
+        key: setting.key,
+        value: setting.value,
+        type: setting.type,
+        description: setting.description,
+        created_at: setting.created_at,
+        updated_at: setting.updated_at,
+      })),
+      pagination: result.pagination,
+    };
+  }
+}

--- a/src/property_management/application/use_case/update_property_setting.ts
+++ b/src/property_management/application/use_case/update_property_setting.ts
@@ -1,0 +1,64 @@
+import { ResourceNotFoundError } from "../../../core/application/error/resource_not_found_error";
+import type { UseCase } from "../../../core/application/use_case/use_case";
+import type { User } from "../../../auth/domain/entity/user";
+import type { PropertySettingType } from "../../domain/entity/property_setting";
+import type { PropertySettingRepository } from "../../domain/repository/property_setting_repository";
+import type { PropertyRepository } from "../../domain/repository/property_repository";
+import { PropertyOwnershipPolicy } from "../../domain/policy/property_ownership_policy";
+
+type Input = {
+  property_id: string;
+  id: string;
+  value?: unknown;
+  type?: PropertySettingType;
+  description?: string | null;
+};
+
+type Output = {
+  id: string;
+  property_id: string;
+  key: string;
+  value: unknown;
+  type: PropertySettingType;
+  description: string | null;
+  created_at: Date;
+  updated_at: Date;
+};
+
+export class UpdatePropertySettingUseCase implements UseCase<Input, Output> {
+  constructor(
+    private readonly propertyRepository: PropertyRepository,
+    private readonly propertySettingRepository: PropertySettingRepository
+  ) {}
+
+  async execute(input: Input, user: User): Promise<Output> {
+    const property = await this.propertyRepository.propertyOfId(
+      input.property_id
+    );
+    PropertyOwnershipPolicy.ensureOwnership(property, user);
+
+    const existing = await this.propertySettingRepository.findById(input.id);
+    if (!existing || existing.property_id !== input.property_id) {
+      throw new ResourceNotFoundError("Property setting");
+    }
+
+    const updated = existing.update({
+      value: input.value,
+      type: input.type,
+      description: input.description,
+    });
+
+    await this.propertySettingRepository.update(updated);
+
+    return {
+      id: updated.id,
+      property_id: updated.property_id,
+      key: updated.key,
+      value: updated.value,
+      type: updated.type,
+      description: updated.description,
+      created_at: updated.created_at,
+      updated_at: updated.updated_at,
+    };
+  }
+}

--- a/src/property_management/domain/entity/property_setting.ts
+++ b/src/property_management/domain/entity/property_setting.ts
@@ -1,0 +1,165 @@
+import { z } from "zod";
+import {
+  baseEntitySchema,
+  type WithoutBaseEntity,
+} from "../../../core/domain/entity/base_entity";
+import { ValidationError } from "../../../core/application/error/validation_error";
+import {
+  boundedJsonValue,
+  refineSettingValueForType,
+  settingDescriptionSchema,
+  settingKeySchema,
+  settingTypeSchema,
+  type SettingType,
+} from "../../../core/domain/value_object/setting_value";
+
+export type PropertySettingType = SettingType;
+
+export const propertySettingSchema = baseEntitySchema
+  .extend({
+    property_id: z.uuidv4("Property ID is required and must be a valid UUID"),
+    key: settingKeySchema,
+    value: boundedJsonValue,
+    type: settingTypeSchema,
+    description: settingDescriptionSchema,
+  })
+  .superRefine((data, ctx) => {
+    // A soft-deleted setting has its `value`/`description` redacted (see
+    // `softDelete()`) and no longer needs to satisfy the original type's
+    // coherence rule — the redacted value is intentionally type-agnostic.
+    if (data.deleted_at) return;
+    refineSettingValueForType(data, ctx);
+  });
+
+export type PropertySettingData = z.infer<typeof propertySettingSchema>;
+
+/**
+ * @kind Entity, Aggregate Root
+ * @bc property_management
+ *
+ * `PropertySetting` is its own aggregate, referencing `Property` only by
+ * `property_id` — it is not a value object nested inside the `Property`
+ * aggregate, and creating/reading/updating it never loads or mutates
+ * `Property` itself beyond the ownership check.
+ *
+ * Security invariant: PropertySetting must NOT store secrets, credentials,
+ * or PII. This is a generic, extensible key/value store for property
+ * configuration (e.g. check-in instructions, display preferences) — it is
+ * NOT a secrets manager. In particular, never use it to store smart lock
+ * access codes/credentials or API tokens/secrets for external booking
+ * platform integrations (Airbnb, Booking.com, etc.); those belong in a
+ * dedicated secrets manager or encrypted store.
+ */
+export class PropertySetting {
+  readonly #data: PropertySettingData;
+
+  private constructor(data: PropertySettingData) {
+    const result = propertySettingSchema.safeParse(data);
+    if (!result.success) {
+      const message =
+        result.error.issues[0]?.message ?? "Invalid property setting";
+      throw new ValidationError(message);
+    }
+    this.#data = result.data;
+  }
+
+  static #nextId(): string {
+    return crypto.randomUUID();
+  }
+
+  static #baseEntityData() {
+    return {
+      id: this.#nextId(),
+      created_at: new Date(),
+      updated_at: new Date(),
+    };
+  }
+
+  public static reconstitute(data: PropertySettingData): PropertySetting {
+    return new PropertySetting(data);
+  }
+
+  public static create(
+    data: WithoutBaseEntity<PropertySettingData>
+  ): PropertySetting {
+    const normalizedKey = data.key.trim();
+    return new PropertySetting({
+      ...data,
+      key: normalizedKey,
+      ...this.#baseEntityData(),
+    });
+  }
+
+  /**
+   * Returns a new PropertySetting with the applied patch.
+   * `key` and `property_id` are immutable and cannot be changed.
+   */
+  public update(patch: {
+    value?: unknown;
+    type?: PropertySettingType;
+    description?: string | null;
+  }): PropertySetting {
+    return new PropertySetting({
+      ...this.#data,
+      value: patch.value !== undefined ? patch.value : this.#data.value,
+      type: patch.type !== undefined ? patch.type : this.#data.type,
+      description:
+        patch.description !== undefined
+          ? patch.description
+          : this.#data.description,
+      updated_at: new Date(),
+    });
+  }
+
+  /**
+   * Returns a new PropertySetting marked as deleted (soft delete). The row
+   * itself is kept — for audit and to back the partial unique index on
+   * `(property_id, key)` — but `value` and `description` are redacted so a
+   * soft-deleted setting doesn't retain its content indefinitely.
+   */
+  public softDelete(): PropertySetting {
+    return new PropertySetting({
+      ...this.#data,
+      value: null,
+      description: null,
+      deleted_at: new Date(),
+      updated_at: new Date(),
+    });
+  }
+
+  get id() {
+    return this.#data.id;
+  }
+
+  get property_id() {
+    return this.#data.property_id;
+  }
+
+  get key() {
+    return this.#data.key;
+  }
+
+  get value() {
+    return this.#data.value;
+  }
+
+  get type() {
+    return this.#data.type;
+  }
+
+  get description() {
+    return this.#data.description ?? null;
+  }
+
+  get created_at() {
+    return this.#data.created_at;
+  }
+
+  get updated_at() {
+    return this.#data.updated_at;
+  }
+
+  get deleted_at() {
+    return this.#data.deleted_at ?? null;
+  }
+}

--- a/src/property_management/domain/policy/property_ownership_policy.ts
+++ b/src/property_management/domain/policy/property_ownership_policy.ts
@@ -1,0 +1,20 @@
+import { ResourceNotFoundError } from "../../../core/application/error/resource_not_found_error";
+import type { User } from "../../../auth/domain/entity/user";
+import type { Property } from "../entity/property";
+
+/**
+ * Ownership check for any use case operating on a property-scoped resource.
+ * "No such property", "property belongs to someone else", and "property was
+ * soft-deleted" all surface as `ResourceNotFoundError("Property")` (404) —
+ * never 401/403 — so a caller can't use the response to probe for the
+ * existence of another user's property, or keep operating on settings scoped
+ * to a property the owner already deleted.
+ */
+export class PropertyOwnershipPolicy {
+  static ensureOwnership(property: Property | null, user: User): Property {
+    if (!property || property.user_id !== user.id || property.deleted_at) {
+      throw new ResourceNotFoundError("Property");
+    }
+    return property;
+  }
+}

--- a/src/property_management/domain/repository/property_setting_repository.ts
+++ b/src/property_management/domain/repository/property_setting_repository.ts
@@ -1,0 +1,23 @@
+import type { PropertySetting } from "../entity/property_setting";
+import type {
+  PaginatedResult,
+  PaginationInput,
+} from "../../../core/application/dto/pagination";
+
+export interface PropertySettingRepository {
+  /**
+   * Persists a new setting, atomically enforcing `maxActiveSettings` against
+   * the property's current active count. Callers must not count-then-save
+   * themselves (TOCTOU): the count check and the insert have to happen under
+   * the same lock, which only the repository can guarantee.
+   */
+  save(setting: PropertySetting, maxActiveSettings: number): Promise<void>;
+  update(setting: PropertySetting): Promise<void>;
+  findById(id: string): Promise<PropertySetting | null>;
+  findByKey(key: string, propertyId: string): Promise<PropertySetting | null>;
+  list(
+    propertyId: string,
+    pagination: PaginationInput
+  ): Promise<PaginatedResult<PropertySetting>>;
+  delete(setting: PropertySetting): Promise<void>;
+}

--- a/src/property_management/infra/database/postgres_repository/property_setting_postgres_repository.ts
+++ b/src/property_management/infra/database/postgres_repository/property_setting_postgres_repository.ts
@@ -1,0 +1,187 @@
+import { and, count, desc, eq, isNull, sql } from "drizzle-orm";
+import {
+  PropertySetting,
+  type PropertySettingData,
+} from "../../../domain/entity/property_setting";
+import type { PropertySettingRepository } from "../../../domain/repository/property_setting_repository";
+import { db } from "../../../../core/infra/database/drizzle/database";
+import { propertySettingsTable } from "../../../../core/infra/database/drizzle/schema";
+import type {
+  PaginatedResult,
+  PaginationInput,
+} from "../../../../core/application/dto/pagination";
+import { calculatePaginationMetadata } from "../../../../core/application/dto/pagination";
+import { ConflictError } from "../../../../core/application/error/conflict_error";
+
+export class PropertySettingPostgresRepository
+  implements PropertySettingRepository
+{
+  /**
+   * Locks the property (via a session-scoped Postgres advisory lock keyed by
+   * `property_id`) before counting active settings and inserting, so the
+   * `maxActiveSettings` check can't race with a concurrent create for the
+   * same property (TOCTOU). The lock is released automatically at the end of
+   * the transaction.
+   */
+  async save(
+    setting: PropertySetting,
+    maxActiveSettings: number
+  ): Promise<void> {
+    const data: PropertySettingData = {
+      id: setting.id,
+      property_id: setting.property_id,
+      key: setting.key,
+      value: setting.value,
+      type: setting.type,
+      description: setting.description,
+      created_at: setting.created_at,
+      updated_at: setting.updated_at,
+      deleted_at: setting.deleted_at,
+    };
+
+    await db.transaction(async tx => {
+      await tx.execute(
+        sql`select pg_advisory_xact_lock(hashtext(${setting.property_id}))`
+      );
+
+      const activeCountResult = await tx
+        .select({ count: count() })
+        .from(propertySettingsTable)
+        .where(
+          and(
+            eq(propertySettingsTable.property_id, setting.property_id),
+            isNull(propertySettingsTable.deleted_at)
+          )
+        );
+
+      const activeCount = activeCountResult[0]?.count
+        ? Number(activeCountResult[0].count)
+        : 0;
+
+      if (activeCount >= maxActiveSettings) {
+        throw new ConflictError(
+          `Property has reached the maximum of ${maxActiveSettings} active settings`
+        );
+      }
+
+      try {
+        const result = await tx
+          .insert(propertySettingsTable)
+          .values(data)
+          .returning();
+
+        if (!result[0]) {
+          throw new Error("Failed to save property setting");
+        }
+      } catch (error) {
+        if (
+          error instanceof Error &&
+          "code" in error &&
+          (error as { code: string }).code === "23505"
+        ) {
+          throw new ConflictError("Property setting key already exists");
+        }
+        throw error;
+      }
+    });
+  }
+
+  async update(setting: PropertySetting): Promise<void> {
+    await db
+      .update(propertySettingsTable)
+      .set({
+        value: setting.value,
+        type: setting.type,
+        description: setting.description,
+        updated_at: setting.updated_at,
+      })
+      .where(eq(propertySettingsTable.id, setting.id));
+  }
+
+  async findById(id: string): Promise<PropertySetting | null> {
+    const result = await db
+      .select()
+      .from(propertySettingsTable)
+      .where(
+        and(
+          eq(propertySettingsTable.id, id),
+          isNull(propertySettingsTable.deleted_at)
+        )
+      )
+      .limit(1);
+
+    if (!result[0]) return null;
+    return PropertySetting.reconstitute(result[0] as PropertySettingData);
+  }
+
+  async findByKey(
+    key: string,
+    propertyId: string
+  ): Promise<PropertySetting | null> {
+    const result = await db
+      .select()
+      .from(propertySettingsTable)
+      .where(
+        and(
+          eq(propertySettingsTable.key, key),
+          eq(propertySettingsTable.property_id, propertyId),
+          isNull(propertySettingsTable.deleted_at)
+        )
+      )
+      .limit(1);
+
+    if (!result[0]) return null;
+    return PropertySetting.reconstitute(result[0] as PropertySettingData);
+  }
+
+  async list(
+    propertyId: string,
+    pagination: PaginationInput
+  ): Promise<PaginatedResult<PropertySetting>> {
+    const whereClause = and(
+      eq(propertySettingsTable.property_id, propertyId),
+      isNull(propertySettingsTable.deleted_at)
+    );
+    const offset = (pagination.page - 1) * pagination.limit;
+
+    const [totalResult, rows] = await Promise.all([
+      db
+        .select({ count: count() })
+        .from(propertySettingsTable)
+        .where(whereClause),
+      db
+        .select()
+        .from(propertySettingsTable)
+        .where(whereClause)
+        .orderBy(desc(propertySettingsTable.created_at))
+        .limit(pagination.limit)
+        .offset(offset),
+    ]);
+
+    const total = totalResult[0]?.count ? Number(totalResult[0].count) : 0;
+    const settings = rows.map(row =>
+      PropertySetting.reconstitute(row as PropertySettingData)
+    );
+
+    return {
+      data: settings,
+      pagination: calculatePaginationMetadata(
+        pagination.page,
+        pagination.limit,
+        total
+      ),
+    };
+  }
+
+  async delete(setting: PropertySetting): Promise<void> {
+    await db
+      .update(propertySettingsTable)
+      .set({
+        value: setting.value,
+        description: setting.description,
+        deleted_at: setting.deleted_at,
+        updated_at: setting.updated_at,
+      })
+      .where(eq(propertySettingsTable.id, setting.id));
+  }
+}

--- a/src/property_management/infra/di/property_management_di.ts
+++ b/src/property_management/infra/di/property_management_di.ts
@@ -1,19 +1,33 @@
 import type { PropertyRepository } from "../../domain/repository/property_repository";
+import type { PropertySettingRepository } from "../../domain/repository/property_setting_repository";
 import { UpdatePropertyUseCase } from "../../application/use_case/update_property";
 import { UpdatePropertyController } from "../../presentation/controller/update_property.controller";
 import { PropertyPostgresRepository } from "../database/postgres_repository/property_postgres_repository";
+import { PropertySettingPostgresRepository } from "../database/postgres_repository/property_setting_postgres_repository";
 import { FindUserPropertiesUseCase } from "../../application/use_case/find_user_properties";
 import { FindUserPropertiesController } from "../../presentation/controller/find_user_properties.controller";
 import { FindPropertyUseCase } from "../../application/use_case/find_property";
 import { FindPropertyController } from "../../presentation/controller/find_property.controller";
 import { CreatePropertyUseCase } from "../../application/use_case/create_property";
 import { CreatePropertyController } from "../../presentation/controller/create_property.controller";
+import { CreatePropertySettingUseCase } from "../../application/use_case/create_property_setting";
+import { CreatePropertySettingController } from "../../presentation/controller/create_property_setting.controller";
+import { GetPropertySettingUseCase } from "../../application/use_case/get_property_setting";
+import { GetPropertySettingController } from "../../presentation/controller/get_property_setting.controller";
+import { ListPropertySettingsUseCase } from "../../application/use_case/list_property_settings";
+import { ListPropertySettingsController } from "../../presentation/controller/list_property_settings.controller";
+import { UpdatePropertySettingUseCase } from "../../application/use_case/update_property_setting";
+import { UpdatePropertySettingController } from "../../presentation/controller/update_property_setting.controller";
+import { DeletePropertySettingUseCase } from "../../application/use_case/delete_property_setting";
+import { DeletePropertySettingController } from "../../presentation/controller/delete_property_setting.controller";
 
 export class PropertyManagementDi {
   #propertyRepository: PropertyRepository;
+  #propertySettingRepository: PropertySettingRepository;
 
   constructor() {
     this.#propertyRepository = new PropertyPostgresRepository();
+    this.#propertySettingRepository = new PropertySettingPostgresRepository();
   }
 
   // Use Cases
@@ -28,6 +42,36 @@ export class PropertyManagementDi {
   }
   makeFindPropertyUseCase() {
     return new FindPropertyUseCase(this.#propertyRepository);
+  }
+  makeCreatePropertySettingUseCase() {
+    return new CreatePropertySettingUseCase(
+      this.#propertyRepository,
+      this.#propertySettingRepository
+    );
+  }
+  makeGetPropertySettingUseCase() {
+    return new GetPropertySettingUseCase(
+      this.#propertyRepository,
+      this.#propertySettingRepository
+    );
+  }
+  makeListPropertySettingsUseCase() {
+    return new ListPropertySettingsUseCase(
+      this.#propertyRepository,
+      this.#propertySettingRepository
+    );
+  }
+  makeUpdatePropertySettingUseCase() {
+    return new UpdatePropertySettingUseCase(
+      this.#propertyRepository,
+      this.#propertySettingRepository
+    );
+  }
+  makeDeletePropertySettingUseCase() {
+    return new DeletePropertySettingUseCase(
+      this.#propertyRepository,
+      this.#propertySettingRepository
+    );
   }
 
   // Controllers
@@ -44,5 +88,30 @@ export class PropertyManagementDi {
   }
   makeFindPropertyController() {
     return new FindPropertyController(this.makeFindPropertyUseCase());
+  }
+  makeCreatePropertySettingController() {
+    return new CreatePropertySettingController(
+      this.makeCreatePropertySettingUseCase()
+    );
+  }
+  makeGetPropertySettingController() {
+    return new GetPropertySettingController(
+      this.makeGetPropertySettingUseCase()
+    );
+  }
+  makeListPropertySettingsController() {
+    return new ListPropertySettingsController(
+      this.makeListPropertySettingsUseCase()
+    );
+  }
+  makeUpdatePropertySettingController() {
+    return new UpdatePropertySettingController(
+      this.makeUpdatePropertySettingUseCase()
+    );
+  }
+  makeDeletePropertySettingController() {
+    return new DeletePropertySettingController(
+      this.makeDeletePropertySettingUseCase()
+    );
   }
 }

--- a/src/property_management/presentation/controller/create_property_setting.controller.ts
+++ b/src/property_management/presentation/controller/create_property_setting.controller.ts
@@ -1,0 +1,111 @@
+import z from "zod";
+import {
+  HttpControllerMethod,
+  type Controller,
+  type ControllerRequest,
+} from "../../../core/presentation/controller/controller";
+import type { User } from "../../../auth/domain/entity/user";
+import type { CreatePropertySettingUseCase } from "../../application/use_case/create_property_setting";
+import type { OpenApiOperation } from "../../../core/presentation/open_api/open_api_types";
+import type { RateLimitPolicy } from "../../../core/application/rate_limit/rate_limit_policy";
+import {
+  bodyFromZod,
+  errorResponse,
+  responseFromZod,
+  validationErrorResponse,
+} from "../../../core/infra/http/swagger/schema_helpers";
+import {
+  boundedJsonValue,
+  settingKeySchema,
+  settingTypeSchema,
+} from "../../../core/domain/value_object/setting_value";
+
+/** Per-IP limit on this write route, mirroring the auth delegated-access
+ * controllers' pattern (see `RegisterAppController`). */
+const RATE_LIMIT_POLICY: RateLimitPolicy = {
+  keyDimension: "peer-ip",
+  windowMs: 60 * 1000,
+  maxAttempts: 30,
+};
+
+const inputSchema = z
+  .object({
+    property_id: z.uuidv4("Property ID must be a valid UUID"),
+    key: settingKeySchema,
+    value: boundedJsonValue,
+    type: settingTypeSchema,
+    description: z
+      .string()
+      .max(500)
+      .optional()
+      .transform(val => val ?? null),
+  })
+  .strict();
+
+const outputSchema = z.object({
+  id: z.string().uuid(),
+  property_id: z.string().uuid(),
+  key: z.string(),
+  value: z.unknown(),
+  type: settingTypeSchema,
+  description: z.string().nullable(),
+  created_at: z.string().datetime(),
+  updated_at: z.string().datetime(),
+});
+
+type Input = z.infer<typeof inputSchema>;
+
+export class CreatePropertySettingController implements Controller {
+  path = "/property/:property_id/settings";
+  method = HttpControllerMethod.POST;
+  inputSchema = inputSchema;
+  rateLimitPolicy = RATE_LIMIT_POLICY;
+
+  openApiSpec: OpenApiOperation = {
+    summary: "Create property setting",
+    description: "Creates a new configuration entry scoped to a property.",
+    tags: ["Property Settings"],
+    parameters: [
+      {
+        name: "property_id",
+        in: "path",
+        required: true,
+        schema: { type: "string", format: "uuid" },
+      },
+    ],
+    requestBody: bodyFromZod(inputSchema.omit({ property_id: true }), {
+      example: {
+        key: "display_currency",
+        value: "BRL",
+        type: "string",
+        description: "Currency used to display prices for this property",
+      },
+    }),
+    responses: {
+      "200": responseFromZod("Property setting created", outputSchema),
+      "401": errorResponse("Unauthorized"),
+      "404": errorResponse("Property not found"),
+      "409": errorResponse(
+        "Property setting key already exists, or the property has reached the maximum number of active settings"
+      ),
+      "422": validationErrorResponse(),
+    },
+  };
+
+  constructor(private readonly useCase: CreatePropertySettingUseCase) {}
+
+  async handle(request: ControllerRequest, user: User): Promise<unknown> {
+    const input = request.body as Input;
+
+    return this.useCase.execute(
+      {
+        property_id: input.property_id,
+        key: input.key,
+        value: input.value,
+        type: input.type,
+        description: input.description,
+      },
+      user
+    );
+  }
+}

--- a/src/property_management/presentation/controller/delete_property_setting.controller.ts
+++ b/src/property_management/presentation/controller/delete_property_setting.controller.ts
@@ -1,0 +1,75 @@
+import z from "zod";
+import {
+  HttpControllerMethod,
+  type Controller,
+  type ControllerRequest,
+} from "../../../core/presentation/controller/controller";
+import type { User } from "../../../auth/domain/entity/user";
+import type { DeletePropertySettingUseCase } from "../../application/use_case/delete_property_setting";
+import type { OpenApiOperation } from "../../../core/presentation/open_api/open_api_types";
+import type { RateLimitPolicy } from "../../../core/application/rate_limit/rate_limit_policy";
+import {
+  errorResponse,
+  noContentResponse,
+} from "../../../core/infra/http/swagger/schema_helpers";
+
+/** Per-IP limit on this write route, mirroring the auth delegated-access
+ * controllers' pattern (see `RegisterAppController`). */
+const RATE_LIMIT_POLICY: RateLimitPolicy = {
+  keyDimension: "peer-ip",
+  windowMs: 60 * 1000,
+  maxAttempts: 30,
+};
+
+const inputSchema = z
+  .object({
+    property_id: z.uuidv4("Property ID must be a valid UUID"),
+    id: z.uuidv4("ID must be a valid UUID"),
+  })
+  .strict();
+
+type Input = z.infer<typeof inputSchema>;
+
+export class DeletePropertySettingController implements Controller {
+  path = "/property/:property_id/settings/:id";
+  method = HttpControllerMethod.DELETE;
+  inputSchema = inputSchema;
+  rateLimitPolicy = RATE_LIMIT_POLICY;
+
+  openApiSpec: OpenApiOperation = {
+    summary: "Delete property setting",
+    description: "Soft-deletes a property-scoped configuration entry.",
+    tags: ["Property Settings"],
+    parameters: [
+      {
+        name: "property_id",
+        in: "path",
+        required: true,
+        schema: { type: "string", format: "uuid" },
+      },
+      {
+        name: "id",
+        in: "path",
+        required: true,
+        schema: { type: "string", format: "uuid" },
+      },
+    ],
+    responses: {
+      "204": noContentResponse("Property setting deleted"),
+      "401": errorResponse("Unauthorized"),
+      "404": errorResponse("Property or property setting not found"),
+    },
+  };
+
+  constructor(private readonly useCase: DeletePropertySettingUseCase) {}
+
+  async handle(request: ControllerRequest, user: User): Promise<unknown> {
+    const input = request.body as Input;
+
+    await this.useCase.execute(
+      { property_id: input.property_id, id: input.id },
+      user
+    );
+    return undefined;
+  }
+}

--- a/src/property_management/presentation/controller/get_property_setting.controller.ts
+++ b/src/property_management/presentation/controller/get_property_setting.controller.ts
@@ -1,0 +1,77 @@
+import z from "zod";
+import {
+  HttpControllerMethod,
+  type Controller,
+  type ControllerRequest,
+} from "../../../core/presentation/controller/controller";
+import type { User } from "../../../auth/domain/entity/user";
+import type { GetPropertySettingUseCase } from "../../application/use_case/get_property_setting";
+import type { OpenApiOperation } from "../../../core/presentation/open_api/open_api_types";
+import {
+  errorResponse,
+  responseFromZod,
+} from "../../../core/infra/http/swagger/schema_helpers";
+import { settingTypeSchema } from "../../../core/domain/value_object/setting_value";
+
+const inputSchema = z
+  .object({
+    property_id: z.uuidv4("Property ID must be a valid UUID"),
+    id: z.uuidv4("ID must be a valid UUID"),
+  })
+  .strict();
+
+const outputSchema = z.object({
+  id: z.string().uuid(),
+  property_id: z.string().uuid(),
+  key: z.string(),
+  value: z.unknown(),
+  type: settingTypeSchema,
+  description: z.string().nullable(),
+  created_at: z.string().datetime(),
+  updated_at: z.string().datetime(),
+});
+
+type Input = z.infer<typeof inputSchema>;
+
+export class GetPropertySettingController implements Controller {
+  path = "/property/:property_id/settings/:id";
+  method = HttpControllerMethod.GET;
+  inputSchema = inputSchema;
+
+  openApiSpec: OpenApiOperation = {
+    summary: "Get property setting by ID",
+    description:
+      "Returns a single configuration entry scoped to a property by its ID.",
+    tags: ["Property Settings"],
+    parameters: [
+      {
+        name: "property_id",
+        in: "path",
+        required: true,
+        schema: { type: "string", format: "uuid" },
+      },
+      {
+        name: "id",
+        in: "path",
+        required: true,
+        schema: { type: "string", format: "uuid" },
+      },
+    ],
+    responses: {
+      "200": responseFromZod("Property setting found", outputSchema),
+      "401": errorResponse("Unauthorized"),
+      "404": errorResponse("Property or property setting not found"),
+    },
+  };
+
+  constructor(private readonly useCase: GetPropertySettingUseCase) {}
+
+  async handle(request: ControllerRequest, user: User): Promise<unknown> {
+    const input = request.body as Input;
+
+    return this.useCase.execute(
+      { property_id: input.property_id, id: input.id },
+      user
+    );
+  }
+}

--- a/src/property_management/presentation/controller/list_property_settings.controller.ts
+++ b/src/property_management/presentation/controller/list_property_settings.controller.ts
@@ -1,0 +1,109 @@
+import z from "zod";
+import {
+  HttpControllerMethod,
+  type Controller,
+  type ControllerRequest,
+} from "../../../core/presentation/controller/controller";
+import type { User } from "../../../auth/domain/entity/user";
+import type { ListPropertySettingsUseCase } from "../../application/use_case/list_property_settings";
+import type { OpenApiOperation } from "../../../core/presentation/open_api/open_api_types";
+import {
+  errorResponse,
+  responseFromZod,
+} from "../../../core/infra/http/swagger/schema_helpers";
+import {
+  DEFAULT_LIMIT,
+  DEFAULT_PAGE,
+  MAX_LIMIT,
+} from "../../../core/application/dto/pagination";
+import { settingTypeSchema } from "../../../core/domain/value_object/setting_value";
+
+const inputSchema = z
+  .object({
+    property_id: z.uuidv4("Property ID must be a valid UUID"),
+    page: z.coerce.number().int().positive().default(DEFAULT_PAGE),
+    limit: z.coerce
+      .number()
+      .int()
+      .positive()
+      .max(MAX_LIMIT)
+      .default(DEFAULT_LIMIT),
+  })
+  .strict();
+
+const outputSchema = z.object({
+  data: z.array(
+    z.object({
+      id: z.string().uuid(),
+      property_id: z.string().uuid(),
+      key: z.string(),
+      value: z.unknown(),
+      type: settingTypeSchema,
+      description: z.string().nullable(),
+      created_at: z.string().datetime(),
+      updated_at: z.string().datetime(),
+    })
+  ),
+  pagination: z.object({
+    page: z.number().int(),
+    limit: z.number().int(),
+    total: z.number().int(),
+    total_pages: z.number().int(),
+    has_next: z.boolean(),
+    has_previous: z.boolean(),
+  }),
+});
+
+type Input = z.infer<typeof inputSchema>;
+
+export class ListPropertySettingsController implements Controller {
+  path = "/property/:property_id/settings";
+  method = HttpControllerMethod.GET;
+  inputSchema = inputSchema;
+
+  openApiSpec: OpenApiOperation = {
+    summary: "List property settings",
+    description:
+      "Returns a paginated list of configuration entries scoped to a single property.",
+    tags: ["Property Settings"],
+    parameters: [
+      {
+        name: "property_id",
+        in: "path",
+        required: true,
+        schema: { type: "string", format: "uuid" },
+      },
+      {
+        name: "page",
+        in: "query",
+        required: false,
+        schema: { type: "integer", default: DEFAULT_PAGE },
+      },
+      {
+        name: "limit",
+        in: "query",
+        required: false,
+        schema: { type: "integer", default: DEFAULT_LIMIT },
+      },
+    ],
+    responses: {
+      "200": responseFromZod("Paginated property settings", outputSchema),
+      "401": errorResponse("Unauthorized"),
+      "404": errorResponse("Property not found"),
+    },
+  };
+
+  constructor(private readonly useCase: ListPropertySettingsUseCase) {}
+
+  async handle(request: ControllerRequest, user: User): Promise<unknown> {
+    const input = request.body as Input;
+
+    return this.useCase.execute(
+      {
+        property_id: input.property_id,
+        pagination: { page: input.page, limit: input.limit },
+      },
+      user
+    );
+  }
+}

--- a/src/property_management/presentation/controller/update_property_setting.controller.ts
+++ b/src/property_management/presentation/controller/update_property_setting.controller.ts
@@ -1,0 +1,103 @@
+import z from "zod";
+import {
+  HttpControllerMethod,
+  type Controller,
+  type ControllerRequest,
+} from "../../../core/presentation/controller/controller";
+import type { User } from "../../../auth/domain/entity/user";
+import type { UpdatePropertySettingUseCase } from "../../application/use_case/update_property_setting";
+import type { OpenApiOperation } from "../../../core/presentation/open_api/open_api_types";
+import type { RateLimitPolicy } from "../../../core/application/rate_limit/rate_limit_policy";
+import {
+  bodyFromZod,
+  errorResponse,
+  responseFromZod,
+  validationErrorResponse,
+} from "../../../core/infra/http/swagger/schema_helpers";
+import {
+  boundedJsonValue,
+  settingTypeSchema,
+} from "../../../core/domain/value_object/setting_value";
+
+/** Per-IP limit on this write route, mirroring the auth delegated-access
+ * controllers' pattern (see `RegisterAppController`). */
+const RATE_LIMIT_POLICY: RateLimitPolicy = {
+  keyDimension: "peer-ip",
+  windowMs: 60 * 1000,
+  maxAttempts: 30,
+};
+
+const inputSchema = z
+  .object({
+    property_id: z.uuidv4("Property ID must be a valid UUID"),
+    id: z.uuidv4("ID must be a valid UUID"),
+    value: boundedJsonValue.optional(),
+    type: settingTypeSchema.optional(),
+    description: z.string().max(500).nullable().optional(),
+  })
+  .strict();
+
+const outputSchema = z.object({
+  id: z.string().uuid(),
+  property_id: z.string().uuid(),
+  key: z.string(),
+  value: z.unknown(),
+  type: settingTypeSchema,
+  description: z.string().nullable(),
+  created_at: z.string().datetime(),
+  updated_at: z.string().datetime(),
+});
+
+type Input = z.infer<typeof inputSchema>;
+
+export class UpdatePropertySettingController implements Controller {
+  path = "/property/:property_id/settings/:id";
+  method = HttpControllerMethod.PUT;
+  inputSchema = inputSchema;
+  rateLimitPolicy = RATE_LIMIT_POLICY;
+
+  openApiSpec: OpenApiOperation = {
+    summary: "Update property setting",
+    description:
+      "Partially updates a property-scoped configuration entry. The key is immutable.",
+    tags: ["Property Settings"],
+    parameters: [
+      {
+        name: "property_id",
+        in: "path",
+        required: true,
+        schema: { type: "string", format: "uuid" },
+      },
+      {
+        name: "id",
+        in: "path",
+        required: true,
+        schema: { type: "string", format: "uuid" },
+      },
+    ],
+    requestBody: bodyFromZod(inputSchema.omit({ property_id: true, id: true })),
+    responses: {
+      "200": responseFromZod("Property setting updated", outputSchema),
+      "401": errorResponse("Unauthorized"),
+      "404": errorResponse("Property or property setting not found"),
+      "422": validationErrorResponse(),
+    },
+  };
+
+  constructor(private readonly useCase: UpdatePropertySettingUseCase) {}
+
+  async handle(request: ControllerRequest, user: User): Promise<unknown> {
+    const input = request.body as Input;
+
+    return this.useCase.execute(
+      {
+        property_id: input.property_id,
+        id: input.id,
+        value: input.value,
+        type: input.type,
+        description: input.description,
+      },
+      user
+    );
+  }
+}

--- a/tests/core/mcp_routes.test.ts
+++ b/tests/core/mcp_routes.test.ts
@@ -140,7 +140,7 @@ describe("POST /mcp", () => {
     expect(body.error).toBe("invalid_token");
   });
 
-  it("lists the 5 registered tools", async () => {
+  it("lists the 10 registered tools", async () => {
     const { user } = await createUserFixture({
       name: "João Silva",
       email: "joao.tools-list@stayhub.dev",
@@ -168,9 +168,14 @@ describe("POST /mcp", () => {
       [
         "book_stay",
         "cancel_stay",
+        "create_property_setting",
+        "delete_property_setting",
+        "get_property_setting",
         "list_properties",
+        "list_property_settings",
         "list_stays",
         "record_expense",
+        "update_property_setting",
       ].sort()
     );
   });

--- a/tests/property_management/create_property_setting_tool.test.ts
+++ b/tests/property_management/create_property_setting_tool.test.ts
@@ -1,0 +1,150 @@
+import type { RequestHandlerExtra } from "@modelcontextprotocol/sdk/shared/protocol.js";
+import type {
+  CallToolResult,
+  ServerNotification,
+  ServerRequest,
+} from "@modelcontextprotocol/sdk/types.js";
+import {
+  McpServer,
+  type RegisteredTool,
+  type ToolCallback,
+} from "@modelcontextprotocol/sdk/server/mcp.js";
+import { describe, expect, it, beforeEach } from "bun:test";
+import { eq } from "drizzle-orm";
+import type { z } from "zod";
+import type { User } from "../../src/auth/domain/entity/user";
+import { db } from "../../src/core/infra/database/drizzle/database";
+import { propertySettingsTable } from "../../src/core/infra/database/drizzle/schema";
+import { registerMcpTool } from "../../src/core/infra/mcp/mcp_tool";
+import { makeCreatePropertySettingTool } from "../../src/core/infra/mcp/tools/create_property_setting";
+import { PropertyManagementDi } from "../../src/property_management/infra/di/property_management_di";
+import { truncate } from "../helpers/database";
+import { createUserFixture } from "../helpers/fixtures/user";
+import { createPropertyFixture } from "../helpers/fixtures/property";
+
+const TABLES = ["property_settings", "properties", "addresses", "users"];
+
+function makeExtra(): RequestHandlerExtra<ServerRequest, ServerNotification> {
+  return {
+    signal: new AbortController().signal,
+    requestId: "test-request-id",
+    sendNotification: async () => {},
+    sendRequest: () => {
+      throw new Error("not implemented in test stub");
+    },
+  };
+}
+
+async function callTool(
+  registeredTool: RegisteredTool,
+  input: Record<string, unknown>,
+  extra: RequestHandlerExtra<ServerRequest, ServerNotification>
+): Promise<CallToolResult> {
+  const handler = registeredTool.handler as ToolCallback<z.ZodRawShape>;
+  return handler(input, extra);
+}
+
+function registerCreatePropertySettingTool(user: User): RegisteredTool {
+  const server = new McpServer({ name: "test-server", version: "1.0.0" });
+  const propertyManagementDi = new PropertyManagementDi();
+
+  return registerMcpTool(
+    server,
+    user,
+    makeCreatePropertySettingTool(propertyManagementDi)
+  );
+}
+
+describe("create_property_setting tool", () => {
+  beforeEach(async () => {
+    await truncate(TABLES);
+  });
+
+  it("creates a setting scoped to a property administered by the authenticated user", async () => {
+    const { user } = await createUserFixture({
+      name: "João Silva",
+      email: "joao@stayhub.dev",
+      password: "password123",
+    });
+    const property = await createPropertyFixture({ userId: user.id });
+
+    const registeredTool = registerCreatePropertySettingTool(user);
+    const result = await callTool(
+      registeredTool,
+      {
+        property_id: property.id,
+        key: "checkin_time",
+        value: "14:00",
+        type: "string",
+        description: "Check-in time for this property",
+      },
+      makeExtra()
+    );
+
+    const text = (result.content as Array<{ text: string }>)[0]?.text ?? "";
+    const output = JSON.parse(text) as { id: string; key: string };
+
+    expect(result.isError).toBeUndefined();
+    expect(output.key).toBe("checkin_time");
+
+    const rows = await db
+      .select()
+      .from(propertySettingsTable)
+      .where(eq(propertySettingsTable.id, output.id));
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.property_id).toBe(property.id);
+  });
+
+  it("does not distinguish another owner's property from a nonexistent one", async () => {
+    const { user: owner } = await createUserFixture({
+      name: "João Silva",
+      email: "joao@stayhub.dev",
+      password: "password123",
+    });
+    const { user: intruder } = await createUserFixture({
+      name: "Maria Souza",
+      email: "maria@stayhub.dev",
+      password: "password123",
+    });
+    const ownerProperty = await createPropertyFixture({ userId: owner.id });
+
+    const registeredTool = registerCreatePropertySettingTool(intruder);
+
+    const resultForAnotherOwnersProperty = await callTool(
+      registeredTool,
+      {
+        property_id: ownerProperty.id,
+        key: "checkin_time",
+        value: "14:00",
+        type: "string",
+      },
+      makeExtra()
+    );
+    const resultForNonexistentProperty = await callTool(
+      registeredTool,
+      {
+        property_id: crypto.randomUUID(),
+        key: "checkin_time",
+        value: "14:00",
+        type: "string",
+      },
+      makeExtra()
+    );
+
+    expect(resultForAnotherOwnersProperty.isError).toBe(true);
+    expect(resultForNonexistentProperty.isError).toBe(true);
+
+    const textForAnotherOwnersProperty =
+      (resultForAnotherOwnersProperty.content as Array<{ text: string }>)[0]
+        ?.text ?? "";
+    const textForNonexistentProperty =
+      (resultForNonexistentProperty.content as Array<{ text: string }>)[0]
+        ?.text ?? "";
+
+    expect(textForAnotherOwnersProperty).toBe(textForNonexistentProperty);
+
+    const rows = await db.select().from(propertySettingsTable);
+    expect(rows).toHaveLength(0);
+  });
+});

--- a/tests/property_management/delete_property_setting_tool.test.ts
+++ b/tests/property_management/delete_property_setting_tool.test.ts
@@ -1,0 +1,153 @@
+import type { RequestHandlerExtra } from "@modelcontextprotocol/sdk/shared/protocol.js";
+import type {
+  CallToolResult,
+  ServerNotification,
+  ServerRequest,
+} from "@modelcontextprotocol/sdk/types.js";
+import {
+  McpServer,
+  type RegisteredTool,
+  type ToolCallback,
+} from "@modelcontextprotocol/sdk/server/mcp.js";
+import { describe, expect, it, beforeEach } from "bun:test";
+import { eq } from "drizzle-orm";
+import type { z } from "zod";
+import type { User } from "../../src/auth/domain/entity/user";
+import { db } from "../../src/core/infra/database/drizzle/database";
+import { propertySettingsTable } from "../../src/core/infra/database/drizzle/schema";
+import { registerMcpTool } from "../../src/core/infra/mcp/mcp_tool";
+import { makeDeletePropertySettingTool } from "../../src/core/infra/mcp/tools/delete_property_setting";
+import { PropertyManagementDi } from "../../src/property_management/infra/di/property_management_di";
+import { truncate } from "../helpers/database";
+import { createUserFixture } from "../helpers/fixtures/user";
+import { createPropertyFixture } from "../helpers/fixtures/property";
+
+const TABLES = ["property_settings", "properties", "addresses", "users"];
+
+function makeExtra(): RequestHandlerExtra<ServerRequest, ServerNotification> {
+  return {
+    signal: new AbortController().signal,
+    requestId: "test-request-id",
+    sendNotification: async () => {},
+    sendRequest: () => {
+      throw new Error("not implemented in test stub");
+    },
+  };
+}
+
+async function callTool(
+  registeredTool: RegisteredTool,
+  input: Record<string, unknown>,
+  extra: RequestHandlerExtra<ServerRequest, ServerNotification>
+): Promise<CallToolResult> {
+  const handler = registeredTool.handler as ToolCallback<z.ZodRawShape>;
+  return handler(input, extra);
+}
+
+function registerDeletePropertySettingTool(user: User): RegisteredTool {
+  const server = new McpServer({ name: "test-server", version: "1.0.0" });
+  const propertyManagementDi = new PropertyManagementDi();
+
+  return registerMcpTool(
+    server,
+    user,
+    makeDeletePropertySettingTool(propertyManagementDi)
+  );
+}
+
+async function createSettingFixture(propertyId: string, user: User) {
+  const propertyManagementDi = new PropertyManagementDi();
+
+  return propertyManagementDi.makeCreatePropertySettingUseCase().execute(
+    {
+      property_id: propertyId,
+      key: "checkin_time",
+      value: "14:00",
+      type: "string",
+      description: "Check-in time for this property",
+    },
+    user
+  );
+}
+
+describe("delete_property_setting tool", () => {
+  beforeEach(async () => {
+    await truncate(TABLES);
+  });
+
+  it("soft-deletes a setting owned by the authenticated user's property and redacts its value/description", async () => {
+    const { user } = await createUserFixture({
+      name: "João Silva",
+      email: "joao@stayhub.dev",
+      password: "password123",
+    });
+    const property = await createPropertyFixture({ userId: user.id });
+    const setting = await createSettingFixture(property.id, user);
+
+    const registeredTool = registerDeletePropertySettingTool(user);
+    const result = await callTool(
+      registeredTool,
+      { property_id: property.id, id: setting.id },
+      makeExtra()
+    );
+
+    expect(result.isError).toBeUndefined();
+
+    const rows = await db
+      .select()
+      .from(propertySettingsTable)
+      .where(eq(propertySettingsTable.id, setting.id));
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.deleted_at).not.toBeNull();
+    expect(rows[0]?.value).toBeNull();
+    expect(rows[0]?.description).toBeNull();
+  });
+
+  it("does not distinguish another owner's property setting from a nonexistent one", async () => {
+    const { user: owner } = await createUserFixture({
+      name: "João Silva",
+      email: "joao@stayhub.dev",
+      password: "password123",
+    });
+    const { user: intruder } = await createUserFixture({
+      name: "Maria Souza",
+      email: "maria@stayhub.dev",
+      password: "password123",
+    });
+    const ownerProperty = await createPropertyFixture({ userId: owner.id });
+    const setting = await createSettingFixture(ownerProperty.id, owner);
+
+    const registeredTool = registerDeletePropertySettingTool(intruder);
+
+    const resultForAnotherOwnersSetting = await callTool(
+      registeredTool,
+      { property_id: ownerProperty.id, id: setting.id },
+      makeExtra()
+    );
+    const resultForNonexistentSetting = await callTool(
+      registeredTool,
+      { property_id: crypto.randomUUID(), id: crypto.randomUUID() },
+      makeExtra()
+    );
+
+    expect(resultForAnotherOwnersSetting.isError).toBe(true);
+    expect(resultForNonexistentSetting.isError).toBe(true);
+
+    const textForAnotherOwnersSetting =
+      (resultForAnotherOwnersSetting.content as Array<{ text: string }>)[0]
+        ?.text ?? "";
+    const textForNonexistentSetting =
+      (resultForNonexistentSetting.content as Array<{ text: string }>)[0]
+        ?.text ?? "";
+
+    expect(textForAnotherOwnersSetting).toBe(textForNonexistentSetting);
+
+    const rows = await db
+      .select()
+      .from(propertySettingsTable)
+      .where(eq(propertySettingsTable.id, setting.id));
+
+    expect(rows[0]?.deleted_at).toBeNull();
+  });
+});

--- a/tests/property_management/get_property_setting_tool.test.ts
+++ b/tests/property_management/get_property_setting_tool.test.ts
@@ -1,0 +1,137 @@
+import type { RequestHandlerExtra } from "@modelcontextprotocol/sdk/shared/protocol.js";
+import type {
+  CallToolResult,
+  ServerNotification,
+  ServerRequest,
+} from "@modelcontextprotocol/sdk/types.js";
+import {
+  McpServer,
+  type RegisteredTool,
+  type ToolCallback,
+} from "@modelcontextprotocol/sdk/server/mcp.js";
+import { describe, expect, it, beforeEach } from "bun:test";
+import type { z } from "zod";
+import type { User } from "../../src/auth/domain/entity/user";
+import { registerMcpTool } from "../../src/core/infra/mcp/mcp_tool";
+import { makeGetPropertySettingTool } from "../../src/core/infra/mcp/tools/get_property_setting";
+import { PropertyManagementDi } from "../../src/property_management/infra/di/property_management_di";
+import { truncate } from "../helpers/database";
+import { createUserFixture } from "../helpers/fixtures/user";
+import { createPropertyFixture } from "../helpers/fixtures/property";
+
+const TABLES = ["property_settings", "properties", "addresses", "users"];
+
+function makeExtra(): RequestHandlerExtra<ServerRequest, ServerNotification> {
+  return {
+    signal: new AbortController().signal,
+    requestId: "test-request-id",
+    sendNotification: async () => {},
+    sendRequest: () => {
+      throw new Error("not implemented in test stub");
+    },
+  };
+}
+
+async function callTool(
+  registeredTool: RegisteredTool,
+  input: Record<string, unknown>,
+  extra: RequestHandlerExtra<ServerRequest, ServerNotification>
+): Promise<CallToolResult> {
+  const handler = registeredTool.handler as ToolCallback<z.ZodRawShape>;
+  return handler(input, extra);
+}
+
+function registerGetPropertySettingTool(user: User): RegisteredTool {
+  const server = new McpServer({ name: "test-server", version: "1.0.0" });
+  const propertyManagementDi = new PropertyManagementDi();
+
+  return registerMcpTool(
+    server,
+    user,
+    makeGetPropertySettingTool(propertyManagementDi)
+  );
+}
+
+async function createSettingFixture(propertyId: string, user: User) {
+  const propertyManagementDi = new PropertyManagementDi();
+
+  return propertyManagementDi.makeCreatePropertySettingUseCase().execute(
+    {
+      property_id: propertyId,
+      key: "checkin_time",
+      value: "14:00",
+      type: "string",
+    },
+    user
+  );
+}
+
+describe("get_property_setting tool", () => {
+  beforeEach(async () => {
+    await truncate(TABLES);
+  });
+
+  it("returns a setting owned by the authenticated user's property", async () => {
+    const { user } = await createUserFixture({
+      name: "João Silva",
+      email: "joao@stayhub.dev",
+      password: "password123",
+    });
+    const property = await createPropertyFixture({ userId: user.id });
+    const setting = await createSettingFixture(property.id, user);
+
+    const registeredTool = registerGetPropertySettingTool(user);
+    const result = await callTool(
+      registeredTool,
+      { property_id: property.id, id: setting.id },
+      makeExtra()
+    );
+
+    const text = (result.content as Array<{ text: string }>)[0]?.text ?? "";
+    const output = JSON.parse(text) as { id: string; key: string };
+
+    expect(result.isError).toBeUndefined();
+    expect(output.id).toBe(setting.id);
+    expect(output.key).toBe("checkin_time");
+  });
+
+  it("does not distinguish another owner's property setting from a nonexistent one", async () => {
+    const { user: owner } = await createUserFixture({
+      name: "João Silva",
+      email: "joao@stayhub.dev",
+      password: "password123",
+    });
+    const { user: intruder } = await createUserFixture({
+      name: "Maria Souza",
+      email: "maria@stayhub.dev",
+      password: "password123",
+    });
+    const ownerProperty = await createPropertyFixture({ userId: owner.id });
+    const setting = await createSettingFixture(ownerProperty.id, owner);
+
+    const registeredTool = registerGetPropertySettingTool(intruder);
+
+    const resultForAnotherOwnersSetting = await callTool(
+      registeredTool,
+      { property_id: ownerProperty.id, id: setting.id },
+      makeExtra()
+    );
+    const resultForNonexistentSetting = await callTool(
+      registeredTool,
+      { property_id: crypto.randomUUID(), id: crypto.randomUUID() },
+      makeExtra()
+    );
+
+    expect(resultForAnotherOwnersSetting.isError).toBe(true);
+    expect(resultForNonexistentSetting.isError).toBe(true);
+
+    const textForAnotherOwnersSetting =
+      (resultForAnotherOwnersSetting.content as Array<{ text: string }>)[0]
+        ?.text ?? "";
+    const textForNonexistentSetting =
+      (resultForNonexistentSetting.content as Array<{ text: string }>)[0]
+        ?.text ?? "";
+
+    expect(textForAnotherOwnersSetting).toBe(textForNonexistentSetting);
+  });
+});

--- a/tests/property_management/list_property_settings_tool.test.ts
+++ b/tests/property_management/list_property_settings_tool.test.ts
@@ -1,0 +1,143 @@
+import type { RequestHandlerExtra } from "@modelcontextprotocol/sdk/shared/protocol.js";
+import type {
+  CallToolResult,
+  ServerNotification,
+  ServerRequest,
+} from "@modelcontextprotocol/sdk/types.js";
+import {
+  McpServer,
+  type RegisteredTool,
+  type ToolCallback,
+} from "@modelcontextprotocol/sdk/server/mcp.js";
+import { describe, expect, it, beforeEach } from "bun:test";
+import type { z } from "zod";
+import type { User } from "../../src/auth/domain/entity/user";
+import { registerMcpTool } from "../../src/core/infra/mcp/mcp_tool";
+import { makeListPropertySettingsTool } from "../../src/core/infra/mcp/tools/list_property_settings";
+import { PropertyManagementDi } from "../../src/property_management/infra/di/property_management_di";
+import { truncate } from "../helpers/database";
+import { createUserFixture } from "../helpers/fixtures/user";
+import { createPropertyFixture } from "../helpers/fixtures/property";
+
+const TABLES = ["property_settings", "properties", "addresses", "users"];
+
+function makeExtra(): RequestHandlerExtra<ServerRequest, ServerNotification> {
+  return {
+    signal: new AbortController().signal,
+    requestId: "test-request-id",
+    sendNotification: async () => {},
+    sendRequest: () => {
+      throw new Error("not implemented in test stub");
+    },
+  };
+}
+
+async function callTool(
+  registeredTool: RegisteredTool,
+  input: Record<string, unknown>,
+  extra: RequestHandlerExtra<ServerRequest, ServerNotification>
+): Promise<CallToolResult> {
+  const handler = registeredTool.handler as ToolCallback<z.ZodRawShape>;
+  return handler(input, extra);
+}
+
+function registerListPropertySettingsTool(user: User): RegisteredTool {
+  const server = new McpServer({ name: "test-server", version: "1.0.0" });
+  const propertyManagementDi = new PropertyManagementDi();
+
+  return registerMcpTool(
+    server,
+    user,
+    makeListPropertySettingsTool(propertyManagementDi)
+  );
+}
+
+async function createSettingFixture(propertyId: string, user: User) {
+  const propertyManagementDi = new PropertyManagementDi();
+
+  return propertyManagementDi.makeCreatePropertySettingUseCase().execute(
+    {
+      property_id: propertyId,
+      key: "checkin_time",
+      value: "14:00",
+      type: "string",
+    },
+    user
+  );
+}
+
+describe("list_property_settings tool", () => {
+  beforeEach(async () => {
+    await truncate(TABLES);
+  });
+
+  it("returns only the settings scoped to the requested property, paginated", async () => {
+    const { user } = await createUserFixture({
+      name: "João Silva",
+      email: "joao@stayhub.dev",
+      password: "password123",
+    });
+    const property = await createPropertyFixture({ userId: user.id });
+    const setting = await createSettingFixture(property.id, user);
+
+    const registeredTool = registerListPropertySettingsTool(user);
+    const result = await callTool(
+      registeredTool,
+      { property_id: property.id, page: 1, limit: 20 },
+      makeExtra()
+    );
+
+    const text = (result.content as Array<{ text: string }>)[0]?.text ?? "";
+    const output = JSON.parse(text) as {
+      data: Array<{ id: string; key: string; property_id: string }>;
+      pagination: { total: number; has_next: boolean };
+    };
+
+    expect(result.isError).toBeUndefined();
+    expect(output.data).toHaveLength(1);
+    expect(output.data[0]?.id).toBe(setting.id);
+    expect(output.data[0]?.key).toBe("checkin_time");
+    expect(output.data[0]?.property_id).toBe(property.id);
+    expect(output.pagination.total).toBe(1);
+    expect(output.pagination.has_next).toBe(false);
+  });
+
+  it("does not distinguish another owner's property from a nonexistent one", async () => {
+    const { user: owner } = await createUserFixture({
+      name: "João Silva",
+      email: "joao@stayhub.dev",
+      password: "password123",
+    });
+    const { user: intruder } = await createUserFixture({
+      name: "Maria Souza",
+      email: "maria@stayhub.dev",
+      password: "password123",
+    });
+    const ownerProperty = await createPropertyFixture({ userId: owner.id });
+
+    const registeredTool = registerListPropertySettingsTool(intruder);
+
+    const resultForAnotherOwnersProperty = await callTool(
+      registeredTool,
+      { property_id: ownerProperty.id, page: 1, limit: 20 },
+      makeExtra()
+    );
+    const resultForNonexistentProperty = await callTool(
+      registeredTool,
+      { property_id: crypto.randomUUID(), page: 1, limit: 20 },
+      makeExtra()
+    );
+
+    expect(resultForAnotherOwnersProperty.isError).toBe(true);
+    expect(resultForNonexistentProperty.isError).toBe(true);
+
+    const textForAnotherOwnersProperty =
+      (resultForAnotherOwnersProperty.content as Array<{ text: string }>)[0]
+        ?.text ?? "";
+    const textForNonexistentProperty =
+      (resultForNonexistentProperty.content as Array<{ text: string }>)[0]
+        ?.text ?? "";
+
+    expect(textForAnotherOwnersProperty).toBe(textForNonexistentProperty);
+  });
+});

--- a/tests/property_management/update_property_setting_tool.test.ts
+++ b/tests/property_management/update_property_setting_tool.test.ts
@@ -1,0 +1,162 @@
+import type { RequestHandlerExtra } from "@modelcontextprotocol/sdk/shared/protocol.js";
+import type {
+  CallToolResult,
+  ServerNotification,
+  ServerRequest,
+} from "@modelcontextprotocol/sdk/types.js";
+import {
+  McpServer,
+  type RegisteredTool,
+  type ToolCallback,
+} from "@modelcontextprotocol/sdk/server/mcp.js";
+import { describe, expect, it, beforeEach } from "bun:test";
+import { eq } from "drizzle-orm";
+import type { z } from "zod";
+import type { User } from "../../src/auth/domain/entity/user";
+import { db } from "../../src/core/infra/database/drizzle/database";
+import { propertySettingsTable } from "../../src/core/infra/database/drizzle/schema";
+import { registerMcpTool } from "../../src/core/infra/mcp/mcp_tool";
+import { makeUpdatePropertySettingTool } from "../../src/core/infra/mcp/tools/update_property_setting";
+import { PropertyManagementDi } from "../../src/property_management/infra/di/property_management_di";
+import { truncate } from "../helpers/database";
+import { createUserFixture } from "../helpers/fixtures/user";
+import { createPropertyFixture } from "../helpers/fixtures/property";
+
+const TABLES = ["property_settings", "properties", "addresses", "users"];
+
+function makeExtra(): RequestHandlerExtra<ServerRequest, ServerNotification> {
+  return {
+    signal: new AbortController().signal,
+    requestId: "test-request-id",
+    sendNotification: async () => {},
+    sendRequest: () => {
+      throw new Error("not implemented in test stub");
+    },
+  };
+}
+
+async function callTool(
+  registeredTool: RegisteredTool,
+  input: Record<string, unknown>,
+  extra: RequestHandlerExtra<ServerRequest, ServerNotification>
+): Promise<CallToolResult> {
+  const handler = registeredTool.handler as ToolCallback<z.ZodRawShape>;
+  return handler(input, extra);
+}
+
+function registerUpdatePropertySettingTool(user: User): RegisteredTool {
+  const server = new McpServer({ name: "test-server", version: "1.0.0" });
+  const propertyManagementDi = new PropertyManagementDi();
+
+  return registerMcpTool(
+    server,
+    user,
+    makeUpdatePropertySettingTool(propertyManagementDi)
+  );
+}
+
+async function createSettingFixture(propertyId: string, user: User) {
+  const propertyManagementDi = new PropertyManagementDi();
+
+  return propertyManagementDi.makeCreatePropertySettingUseCase().execute(
+    {
+      property_id: propertyId,
+      key: "checkin_time",
+      value: "14:00",
+      type: "string",
+    },
+    user
+  );
+}
+
+describe("update_property_setting tool", () => {
+  beforeEach(async () => {
+    await truncate(TABLES);
+  });
+
+  it("updates a setting owned by the authenticated user's property", async () => {
+    const { user } = await createUserFixture({
+      name: "João Silva",
+      email: "joao@stayhub.dev",
+      password: "password123",
+    });
+    const property = await createPropertyFixture({ userId: user.id });
+    const setting = await createSettingFixture(property.id, user);
+
+    const registeredTool = registerUpdatePropertySettingTool(user);
+    const result = await callTool(
+      registeredTool,
+      {
+        property_id: property.id,
+        id: setting.id,
+        value: "15:00",
+      },
+      makeExtra()
+    );
+
+    const text = (result.content as Array<{ text: string }>)[0]?.text ?? "";
+    const output = JSON.parse(text) as { id: string; value: string };
+
+    expect(result.isError).toBeUndefined();
+    expect(output.id).toBe(setting.id);
+    expect(output.value).toBe("15:00");
+
+    const rows = await db
+      .select()
+      .from(propertySettingsTable)
+      .where(eq(propertySettingsTable.id, setting.id));
+
+    expect(rows[0]?.value).toBe("15:00");
+  });
+
+  it("does not distinguish another owner's property setting from a nonexistent one", async () => {
+    const { user: owner } = await createUserFixture({
+      name: "João Silva",
+      email: "joao@stayhub.dev",
+      password: "password123",
+    });
+    const { user: intruder } = await createUserFixture({
+      name: "Maria Souza",
+      email: "maria@stayhub.dev",
+      password: "password123",
+    });
+    const ownerProperty = await createPropertyFixture({ userId: owner.id });
+    const setting = await createSettingFixture(ownerProperty.id, owner);
+
+    const registeredTool = registerUpdatePropertySettingTool(intruder);
+
+    const resultForAnotherOwnersSetting = await callTool(
+      registeredTool,
+      { property_id: ownerProperty.id, id: setting.id, value: "hacked" },
+      makeExtra()
+    );
+    const resultForNonexistentSetting = await callTool(
+      registeredTool,
+      {
+        property_id: crypto.randomUUID(),
+        id: crypto.randomUUID(),
+        value: "hacked",
+      },
+      makeExtra()
+    );
+
+    expect(resultForAnotherOwnersSetting.isError).toBe(true);
+    expect(resultForNonexistentSetting.isError).toBe(true);
+
+    const textForAnotherOwnersSetting =
+      (resultForAnotherOwnersSetting.content as Array<{ text: string }>)[0]
+        ?.text ?? "";
+    const textForNonexistentSetting =
+      (resultForNonexistentSetting.content as Array<{ text: string }>)[0]
+        ?.text ?? "";
+
+    expect(textForAnotherOwnersSetting).toBe(textForNonexistentSetting);
+
+    const rows = await db
+      .select()
+      .from(propertySettingsTable)
+      .where(eq(propertySettingsTable.id, setting.id));
+
+    expect(rows[0]?.value).toBe("14:00");
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `PropertySetting`, a per-property key/value configuration store in `property_management`, sibling to the existing global `AppSetting` (`backoffice`) — authorized by property ownership instead of admin role, with a shared type/value validation kernel reused by both entities.
- Exposes the same CRUD surface as 5 MCP tools (`list/get/create/update/delete_property_setting`), with the OAuth consent text updated to match.
- Includes pre-merge security fixes from the Analista de Segurança review: LGPD purge (`purgeUserData` now transactional and deletes settings before cascading), a TOCTOU race on the per-property setting cap (fixed via advisory lock), control-character rejection, value/description redaction on soft delete, an ownership policy that rejects soft-deleted properties, a secret-key denylist, and rate limiting on the write routes.

## Test plan
- [x] `bun run lint:check` / `bun run format:check` / `tsc --noEmit` — clean
- [x] Full suite via the pre-push hook (`bun test --env-file=.env.test --preload ./tests/setup.ts`): **156 pass, 0 fail** across 29 files
- [x] Ownership isolation covered for all 5 MCP tools and the HTTP routes (another user's property setting is indistinguishable from a nonexistent one — 404, never 401/403)
- [x] Manually reproduced and fixed a real bug found during verification: `property_settings.value` was `NOT NULL`, so soft-delete redaction crashed every delete (see migration `0005_absent_squadron_supreme.sql`)

Full domain/security decision log: `.claude/plans/2026-08-15-configuracao-por-propriedade.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)