### PR TITLE
chore: rename product branding from stayhub to sogio

### DIFF
--- a/.claude/personas/arquiteto.md
+++ b/.claude/personas/arquiteto.md
@@ -33,7 +33,7 @@ Ele não entra em detalhes de implementação. Seu foco é entender **o quê** e
 
 ---
 
-## Contexto do Domínio: StayHub
+## Contexto do Domínio: Sogio
 
 ### Propósito do Negócio
 

--- a/.claude/plans/2026-08-15-renomear-stayhub-para-sogio.md
+++ b/.claude/plans/2026-08-15-renomear-stayhub-para-sogio.md
@@ -1,0 +1,102 @@
+# Renomear produto StayHub -> Sogio
+
+## Objective
+
+Substituir o nome de marca "StayHub"/"stayhub" por "Sogio"/"sogio" em todo o
+repositório (código, docs, config), no repositório GitHub, no banco de dados
+local e nas pastas locais do projeto — sem alterar nenhum termo de domínio
+(bounded contexts, agregados, rotas) e sem impactar produção.
+
+## Personas
+
+- **Arquiteto** — validou que é rename de branding, não de domínio; ver
+  parecer completo no histórico da task. Nenhum bloqueio arquitetural.
+- **Desenvolvedor** — executa o rename dentro da worktree.
+- **Analista de Segurança** — revisa o diff (foco: `cors.middleware.ts`,
+  `docker-compose.yml`, mudanças que tocam auth/OAuth).
+
+## Decisões do usuário
+
+1. Repositório GitHub: `GustavoMelloGit/stayhub-api` -> `GustavoMelloGit/sogio-api`
+2. Banco local (`docker-compose.yml`, `.env`, `.env.test`): `stayhub`/`stayhub_test` -> `sogio`/`sogio_test`. Produção **não** é tocada nesta task.
+3. Referências ao frontend (`stayhub-front` -> `sogio-front`) nos comentários do backend — o repo do frontend em si está fora de escopo.
+4. Pastas locais do projeto (`~/Documents/Personal/stayhub/stayhub-api` -> `~/Documents/Personal/sogio/sogio-api`) — renomeadas por último, depois do merge.
+
+## Regra de ouro (Arquiteto)
+
+Buscar e trocar apenas o token de marca `stayhub`/`StayHub` (case-insensitive).
+**Nunca** tocar em ocorrências de `stay` isoladas — `Stay`, `book_stay`,
+`list_stays`, rota `/stays`, tabela `stays`, etc. são termos de domínio e
+permanecem exatamente como estão.
+
+## Mapped Changes
+
+### Código-fonte (dentro da worktree, via PR)
+
+- `src/core/infra/mcp/routes.ts:30` — `MCP_SERVER_NAME` ("stayhub" -> "sogio"), visível no `initialize` do protocolo MCP
+- `src/core/infra/mcp/mcp_server.ts:14` — comentário
+- `src/core/infra/http/swagger/open_api_builder.ts:49` — título/descrição OpenAPI
+- `src/core/infra/http/swagger/scalar_ui.ts:33,49` — labels da doc
+- `src/core/infra/http/swagger/swagger_ui.ts:28` — labels da doc
+- `src/core/infra/config/environments.ts:33` — comentário (`stayhub-front` -> `sogio-front`)
+- `src/core/presentation/middleware/cors.middleware.ts:15,115,150,151` — **apenas comentários**; lógica real usa `frontBaseUrl` (env), não muda. Trocar o par de exemplo anti-spoofing de forma coerente (`front.sogio.com` vs `front.sogio.com.evil.com`)
+- `src/auth/application/use_case/decide_authorization_request.ts:42` — comentário
+- `src/auth/application/use_case/list_connected_apps.ts:24` — comentário
+- `src/auth/domain/service/oauth_scope_policy.ts:45` — texto de fallback de `describeScope()` (display-only, não persistido; não invalida consentimentos existentes — confirmado pelo Arquiteto)
+- `src/auth/presentation/controller/delegated_access/authorize.controller.ts:26` — comentário
+- `src/auth/presentation/controller/delegated_access/list_connected_apps.controller.ts:28` — comentário
+- `src/auth/presentation/controller/auth/sign_in.controller.ts:47` — exemplo OpenAPI (e-mail de exemplo)
+- `src/auth/presentation/controller/auth/register_user.controller.ts:51` — exemplo OpenAPI
+- `src/property_management/presentation/controller/create_property.controller.ts:103` — URL de exemplo de imagem
+- `tests/**/*.test.ts`, `tests/helpers/fixtures/delegated_access.ts` — strings arbitrárias (emails, issuers de teste); trocar fixture + assertions juntos, por arquivo
+
+### Docs / config (dentro da worktree, via PR)
+
+- `README.md`
+- `CLAUDE.md`
+- `package.json` (`"name": "stayhub-api"` -> `"sogio-api"`)
+- `docker-compose.yml` — `container_name`, `POSTGRES_DB`, **e adicionar `name: sogio-api` explícito no topo** para não depender do nome do diretório (evita quebrar o volume de novo no futuro)
+- `.claude/personas/arquiteto.md` — seção "Contexto do Domínio: StayHub" -> "Sogio" (só o nome do produto, terminologia de domínio intacta)
+- `bun.lock` — **não editar à mão**; regenerar via `bun install` após mudar `package.json`
+
+### Fora do escopo desta PR (não tocar)
+
+- `.github/workflows/deploy.yml` (`cd stayhub_api`, `pm2 restart stayhub_api`) — identificadores reais da VPS de produção; renomear exige coordenação manual com o servidor, fora desta task
+- Linha comentada de `DATABASE_URL` de produção em `.env` (credencial real) — não alterar nem reproduzir
+- `.claude/plans/*.md` já existentes — histórico imutável
+- Alias do conector MCP do usuário (`stayhub-prod`, fora do repositório, aponta pra produção) — pendência para quando produção for renomeada
+
+### Local, fora do git (feito depois do merge, direto na raiz)
+
+- `.env` — `DATABASE_URL` -> `.../sogio` (linha de produção comentada permanece intocada)
+- `.env.test` — `DATABASE_URL` -> `.../sogio_test`
+- Recriar ambiente Docker local (o volume é derivado do nome do projeto/diretório — vai mudar de qualquer forma): `docker compose down`, `docker compose up -d`, `bun run db:push`, `bun run db:push:test`
+- Renomear repositório GitHub: `gh repo rename sogio-api`, depois `git remote set-url origin` (local e, se aplicável, na worktree antes de removê-la)
+- Renomear pastas locais: `~/Documents/Personal/stayhub` -> `~/Documents/Personal/sogio`, `stayhub-api` -> `sogio-api`
+
+## Tasks
+
+1. **Arquiteto valida escopo** — concluído.
+   - Dependencies: none
+2. **Criar branch + worktree** (`rename-stayhub-to-sogio`)
+   - Dependencies: task 1
+3. **Desenvolvedor executa o rename** (código-fonte + docs/config listados acima, dentro da worktree)
+   - Dependencies: task 2
+4. **Rodar `bun install`, `lint:check`, `format:check`, `typecheck`** na worktree
+   - Dependencies: task 3
+5. **Commit + push + `gh pr create`**
+   - Dependencies: task 4
+6. **Analista de Segurança revisa o diff da PR**
+   - Dependencies: task 5
+7. **Merge da PR** (após revisão de segurança, confirmação do usuário)
+   - Dependencies: task 6
+8. **Remover worktree**
+   - Dependencies: task 7
+9. **Cutover local**: `.env`/`.env.test`, recriar Docker, `db:push`/`db:push:test`
+   - Dependencies: task 8 (precisa do `docker-compose.yml` atualizado já em `main`)
+10. **Renomear repositório no GitHub + `git remote set-url`**
+    - Dependencies: task 8
+11. **Renomear pastas locais** (`mv`)
+    - Dependencies: tasks 9, 10 (evita mover o diretório com worktree/remote ainda em uso)
+
+> Tasks 9 e 10 podem rodar em paralelo entre si (ambas dependem só da 8).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,7 @@ Os testes ficam em `tests/<bounded context>/<test name>.test.ts`.
 
 ## Arquitetura
 
-**StayHub API** é um backend de gestão de aluguel de imóveis construído com Bun + TypeScript + PostgreSQL (Drizzle ORM). Segue **Clean Architecture** com separação estrita de camadas.
+**Sogio API** é um backend de gestão de aluguel de imóveis construído com Bun + TypeScript + PostgreSQL (Drizzle ORM). Segue **Clean Architecture** com separação estrita de camadas.
 
 ### Estrutura de Camadas
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# StayHub API
+# Sogio API
 
-This is the backend API for StayHub, a platform for managing property rentals. This project is currently under development.
+This is the backend API for Sogio, a platform for managing property rentals. This project is currently under development.
 
 ## Getting Started
 
@@ -15,11 +15,11 @@ These instructions will get you a copy of the project up and running on your loc
 
 1. Clone the repository:
    ```bash
-   git clone https://github.com/GustavoMelloGit/stayhub-api
+   git clone https://github.com/GustavoMelloGit/sogio-api
    ```
 2. Navigate to the project directory:
    ```bash
-   cd stayhub-api
+   cd sogio-api
    ```
 
 ### Running the application

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,13 @@
+name: sogio-api
 services:
   db:
     image: postgres:17-alpine
-    container_name: stayhub_db
+    container_name: sogio_db
     restart: unless-stopped
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: mypassword
-      POSTGRES_DB: stayhub
+      POSTGRES_DB: sogio
     ports:
       - "5433:5432"
     volumes:

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "stayhub-api",
+  "name": "sogio-api",
   "module": "src/index.ts",
   "type": "module",
   "private": true,

--- a/src/auth/application/use_case/decide_authorization_request.ts
+++ b/src/auth/application/use_case/decide_authorization_request.ts
@@ -39,7 +39,7 @@ const ACCESS_DENIED_DESCRIPTION = "The user denied the authorization request.";
  * Approve or deny a Pending Authorization Request (task 10, contract step
  * 6) — and, unchanged, the endpoint the reconnection shortcut calls
  * silently: same path, same atomic claim, no separate endpoint (see the
- * plan's "Contrato com o stayhub-front").
+ * plan's "Contrato com o sogio-front").
  *
  * The request's one-shot claim (E4) is a single atomic
  * `UPDATE ... WHERE consumed_at IS NULL AND expires_at > now() RETURNING`

--- a/src/auth/application/use_case/list_connected_apps.ts
+++ b/src/auth/application/use_case/list_connected_apps.ts
@@ -21,7 +21,7 @@ export type ConnectedApp = {
 };
 
 /**
- * "Aplicativos conectados" (task 14, contrato com o stayhub-front #1 e #3).
+ * "Aplicativos conectados" (task 14, contrato com o sogio-front #1 e #3).
  *
  * **Escopo por usuário.** `user.id` vem exclusivamente do middleware de
  * autenticação da sessão do app — nunca de um parâmetro que o cliente

--- a/src/auth/domain/service/oauth_scope_policy.ts
+++ b/src/auth/domain/service/oauth_scope_policy.ts
@@ -42,6 +42,6 @@ const SCOPE_DESCRIPTIONS: Readonly<Record<string, string>> = {
  */
 export function describeScope(scope: string): string {
   return (
-    SCOPE_DESCRIPTIONS[scope] ?? "Access your StayHub account on your behalf."
+    SCOPE_DESCRIPTIONS[scope] ?? "Access your Sogio account on your behalf."
   );
 }

--- a/src/auth/presentation/controller/auth/register_user.controller.ts
+++ b/src/auth/presentation/controller/auth/register_user.controller.ts
@@ -48,7 +48,7 @@ export class RegisterUserController implements Controller {
     requestBody: bodyFromZod(inputSchema, {
       example: {
         name: "Gustavo Marques",
-        email: "gustavo@stayhub.com",
+        email: "gustavo@sogio.com",
         password: "SenhaForte123",
       },
     }),

--- a/src/auth/presentation/controller/auth/sign_in.controller.ts
+++ b/src/auth/presentation/controller/auth/sign_in.controller.ts
@@ -44,7 +44,7 @@ export class SignInController implements Controller {
     tags: ["Auth"],
     requestBody: bodyFromZod(inputSchema, {
       example: {
-        email: "gustavo@stayhub.com",
+        email: "gustavo@sogio.com",
         password: "SenhaForte123",
       },
     }),

--- a/src/auth/presentation/controller/delegated_access/authorize.controller.ts
+++ b/src/auth/presentation/controller/delegated_access/authorize.controller.ts
@@ -23,7 +23,7 @@ import { parseUniqueQueryParams } from "./unique_query_params";
  * Path and query parameter the front's consent page is reached at. Owned
  * here, next to the only place that builds this redirect, and exported so
  * task 10's "pending request" controllers on this side (if any) and the
- * `stayhub-front` implementation agree on the same contract: the front
+ * `sogio-front` implementation agree on the same contract: the front
  * receives nothing but this opaque identifier — no OAuth parameter ever
  * reaches it.
  */

--- a/src/auth/presentation/controller/delegated_access/list_connected_apps.controller.ts
+++ b/src/auth/presentation/controller/delegated_access/list_connected_apps.controller.ts
@@ -25,7 +25,7 @@ const outputSchema = z.array(
 
 /**
  * `GET /auth/connected-apps` — tela de "aplicativos conectados" (task 14,
- * contrato com o stayhub-front). Autenticado pela sessão normal do app
+ * contrato com o sogio-front). Autenticado pela sessão normal do app
  * (`authenticated: true` na rota, JWT Bearer), nunca pela credencial OAuth
  * (Decisão Arquitetural 12) — um aplicativo conectado não pode se
  * auto-gerenciar nem enxergar os demais, o que fecharia o ciclo de

--- a/src/core/infra/config/environments.ts
+++ b/src/core/infra/config/environments.ts
@@ -30,7 +30,7 @@ const envSchema = z
       })
       .optional(),
     /**
-     * Public base URL of the stayhub-front, with no trailing slash. It plays
+     * Public base URL of the sogio-front, with no trailing slash. It plays
      * two roles: the destination of the 302 redirect a successful
      * `/authorize` call issues (the front's consent page, identified only by
      * the opaque pending-request id — never any OAuth parameter, per the

--- a/src/core/infra/http/swagger/open_api_builder.ts
+++ b/src/core/infra/http/swagger/open_api_builder.ts
@@ -46,7 +46,7 @@ export class OpenApiBuilder {
     return {
       openapi: "3.0.0",
       info: {
-        title: "StayHub API",
+        title: "Sogio API",
         version: "1.0.0",
         description: "Property rental management API",
       },

--- a/src/core/infra/http/swagger/scalar_ui.ts
+++ b/src/core/infra/http/swagger/scalar_ui.ts
@@ -30,7 +30,7 @@ export function scalarUiHtml(
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>StayHub API Docs</title>
+    <title>Sogio API Docs</title>
     <style>
       body { margin: 0; }
     </style>
@@ -46,7 +46,7 @@ export function scalarUiHtml(
         theme: 'purple',
         persistAuth: true,
         mcp: {
-          name: 'StayHub MCP',
+          name: 'Sogio MCP',
           url: window.location.origin + '/mcp',
         },
         authentication: savedToken

--- a/src/core/infra/http/swagger/swagger_ui.ts
+++ b/src/core/infra/http/swagger/swagger_ui.ts
@@ -25,7 +25,7 @@ export function swaggerUiHtml(
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>StayHub API Docs</title>
+    <title>Sogio API Docs</title>
     <link
       rel="stylesheet"
       href="https://unpkg.com/swagger-ui-dist@5/swagger-ui.css"

--- a/src/core/infra/mcp/mcp_server.ts
+++ b/src/core/infra/mcp/mcp_server.ts
@@ -11,7 +11,7 @@ export type CreateMcpServerOptions = {
 };
 
 /**
- * Builds an MCP server for a single request, wired to the StayHub error
+ * Builds an MCP server for a single request, wired to the Sogio error
  * mapping pipeline and bound to `user` — the caller already resolved by the
  * transport gate in `routes.ts` before this server was even instantiated.
  * Every tool registered through `registerMcpTool` (or passed in `tools`)

--- a/src/core/infra/mcp/routes.ts
+++ b/src/core/infra/mcp/routes.ts
@@ -27,7 +27,7 @@ import {
   makeUpdatePropertySettingTool,
 } from "./tools";
 
-const MCP_SERVER_NAME = "stayhub";
+const MCP_SERVER_NAME = "sogio";
 const MCP_SERVER_VERSION = "1.0.0";
 
 /**

--- a/src/core/presentation/middleware/cors.middleware.ts
+++ b/src/core/presentation/middleware/cors.middleware.ts
@@ -12,7 +12,7 @@ export class CorsMiddleware {
        * Exactly the front's origin (E8) — not a `https://*` wildcard. The
        * previous wildcard accepted any HTTPS origin, which combined with
        * `Access-Control-Allow-Credentials: true` below is effectively `*`
-       * with credentials enabled. `stayhub-front` is the API's one
+       * with credentials enabled. `sogio-front` is the API's one
        * legitimate browser caller (the app itself and the OAuth consent
        * screen both live there), so this is a like-for-like tightening, not
        * a behavior change for real traffic.
@@ -112,7 +112,7 @@ export class CorsMiddleware {
    *
    * `/mcp` (task 14) reuses this same policy instead of a third CORS mode:
    * it needs the same "any origin, no ambient credential" shape, since a
-   * browser-based MCP client isn't `stayhub-front` and can't be restricted
+   * browser-based MCP client isn't `sogio-front` and can't be restricted
    * to its origin. `/mcp` carries no cookie or other ambient browser
    * credential to protect — the bearer token is attached explicitly by the
    * caller's own JavaScript, not sent automatically the way a cookie would
@@ -147,8 +147,8 @@ export class CorsMiddleware {
        * allowance) is a genuine prefix match. Anything else — in
        * particular `frontBaseUrl` in production (E8) — has to match the
        * origin exactly; a `startsWith` here would let
-       * `https://front.stayhub.com.evil.com` through against an allowed
-       * origin of `https://front.stayhub.com`.
+       * `https://front.sogio.com.evil.com` through against an allowed
+       * origin of `https://front.sogio.com`.
        */
       if (allowedOrigin.endsWith("*")) {
         return origin.startsWith(allowedOrigin.slice(0, -1));

--- a/src/property_management/presentation/controller/create_property.controller.ts
+++ b/src/property_management/presentation/controller/create_property.controller.ts
@@ -100,7 +100,7 @@ export class CreatePropertyController implements Controller {
           country: "Brasil",
           complement: "Apto 302",
         },
-        images: ["https://cdn.stayhub.com/properties/vista-mar/1.jpg"],
+        images: ["https://cdn.sogio.com/properties/vista-mar/1.jpg"],
         capacity: 4,
       },
     }),

--- a/tests/auth/delegated_access/app_registration_repository.test.ts
+++ b/tests/auth/delegated_access/app_registration_repository.test.ts
@@ -51,7 +51,7 @@ describe("AppRegistrationPostgresRepository", () => {
   it("does not purge a registration with a consent, even if old", async () => {
     const { user } = await createUserFixture({
       name: "Ada Lovelace",
-      email: "ada@stayhub.dev",
+      email: "ada@sogio.dev",
       password: "correct-horse-battery",
     });
     const old = new Date(Date.now() - 90 * 24 * 60 * 60 * 1000);

--- a/tests/auth/delegated_access/authorization_code_repository.test.ts
+++ b/tests/auth/delegated_access/authorization_code_repository.test.ts
@@ -24,7 +24,7 @@ describe("AuthorizationCodePostgresRepository", () => {
   async function setup() {
     const { user } = await createUserFixture({
       name: "Ada Lovelace",
-      email: "ada@stayhub.dev",
+      email: "ada@sogio.dev",
       password: "correct-horse-battery",
     });
     const app = await createAppRegistrationFixture();

--- a/tests/auth/delegated_access/consent_repository.test.ts
+++ b/tests/auth/delegated_access/consent_repository.test.ts
@@ -17,7 +17,7 @@ describe("ConsentPostgresRepository", () => {
   it("creates a consent and finds it by id", async () => {
     const { user } = await createUserFixture({
       name: "Ada Lovelace",
-      email: "ada@stayhub.dev",
+      email: "ada@sogio.dev",
       password: "correct-horse-battery",
     });
     const app = await createAppRegistrationFixture();
@@ -38,12 +38,12 @@ describe("ConsentPostgresRepository", () => {
   it("finds a consent by (user, app) and returns null for other combinations", async () => {
     const { user } = await createUserFixture({
       name: "Ada Lovelace",
-      email: "ada@stayhub.dev",
+      email: "ada@sogio.dev",
       password: "correct-horse-battery",
     });
     const { user: otherUser } = await createUserFixture({
       name: "Grace Hopper",
-      email: "grace@stayhub.dev",
+      email: "grace@sogio.dev",
       password: "correct-horse-battery",
     });
     const app = await createAppRegistrationFixture();
@@ -64,7 +64,7 @@ describe("ConsentPostgresRepository", () => {
   it("revokes a consent, setting revoked_at", async () => {
     const { user } = await createUserFixture({
       name: "Ada Lovelace",
-      email: "ada@stayhub.dev",
+      email: "ada@sogio.dev",
       password: "correct-horse-battery",
     });
     const app = await createAppRegistrationFixture();

--- a/tests/auth/delegated_access/issued_credential_repository.test.ts
+++ b/tests/auth/delegated_access/issued_credential_repository.test.ts
@@ -25,7 +25,7 @@ describe("IssuedCredentialPostgresRepository", () => {
   async function setupConsent() {
     const { user } = await createUserFixture({
       name: "Ada Lovelace",
-      email: "ada@stayhub.dev",
+      email: "ada@sogio.dev",
       password: "correct-horse-battery",
     });
     const app = await createAppRegistrationFixture();
@@ -66,7 +66,7 @@ describe("IssuedCredentialPostgresRepository", () => {
       access_token_expires_at: new Date(Date.now() + 60_000),
       refresh_token_digest: secretService.digest("refresh-a"),
       refresh_token_expires_at: new Date(Date.now() + 60_000),
-      resource: "https://api.stayhub.dev/mcp",
+      resource: "https://api.sogio.dev/mcp",
     });
     await repository.issue(first);
 
@@ -77,7 +77,7 @@ describe("IssuedCredentialPostgresRepository", () => {
       access_token_expires_at: new Date(Date.now() + 60_000),
       refresh_token_digest: secretService.digest("refresh-b"),
       refresh_token_expires_at: new Date(Date.now() + 60_000),
-      resource: "https://api.stayhub.dev/mcp",
+      resource: "https://api.sogio.dev/mcp",
     });
 
     await expect(repository.issue(duplicate)).rejects.toThrow();

--- a/tests/auth/rbac.test.ts
+++ b/tests/auth/rbac.test.ts
@@ -14,7 +14,7 @@ describe("RBAC — auth endpoints", () => {
         method: "POST",
         body: JSON.stringify({
           name: "Test User",
-          email: "test@stayhub.dev",
+          email: "test@sogio.dev",
           password: "password123",
         }),
       });
@@ -32,7 +32,7 @@ describe("RBAC — auth endpoints", () => {
         method: "POST",
         body: JSON.stringify({
           name: "Would-be Admin",
-          email: "attacker@stayhub.dev",
+          email: "attacker@sogio.dev",
           password: "password123",
           role: "admin",
         }),
@@ -51,7 +51,7 @@ describe("RBAC — auth endpoints", () => {
     it("returns role in output", async () => {
       const { user, plainPassword } = await createUserFixture({
         name: "Ada Lovelace",
-        email: "ada@stayhub.dev",
+        email: "ada@sogio.dev",
         password: "correct-horse-battery",
       });
 

--- a/tests/auth/sign_in.test.ts
+++ b/tests/auth/sign_in.test.ts
@@ -11,7 +11,7 @@ describe("POST /auth/sign-in", () => {
   it("200 — returns token and user on valid credentials", async () => {
     const { user, plainPassword } = await createUserFixture({
       name: "Ada Lovelace",
-      email: "ada@stayhub.dev",
+      email: "ada@sogio.dev",
       password: "correct-horse-battery",
     });
 
@@ -40,7 +40,7 @@ describe("POST /auth/sign-in", () => {
   it("401 — rejects wrong password", async () => {
     const { user } = await createUserFixture({
       name: "Ada Lovelace",
-      email: "ada@stayhub.dev",
+      email: "ada@sogio.dev",
       password: "correct-horse-battery",
     });
 
@@ -57,14 +57,14 @@ describe("POST /auth/sign-in", () => {
   it("401 — rejects unknown email with same message as wrong password", async () => {
     await createUserFixture({
       name: "Ada Lovelace",
-      email: "ada@stayhub.dev",
+      email: "ada@sogio.dev",
       password: "correct-horse-battery",
     });
 
     const resWrongPassword = await api("/auth/sign-in", {
       method: "POST",
       body: JSON.stringify({
-        email: "ada@stayhub.dev",
+        email: "ada@sogio.dev",
         password: "wrong-password",
       }),
     });
@@ -76,7 +76,7 @@ describe("POST /auth/sign-in", () => {
     const resUnknownEmail = await api("/auth/sign-in", {
       method: "POST",
       body: JSON.stringify({
-        email: "ghost@stayhub.dev",
+        email: "ghost@sogio.dev",
         password: "any-password",
       }),
     });

--- a/tests/backoffice/app_setting_crud.test.ts
+++ b/tests/backoffice/app_setting_crud.test.ts
@@ -22,7 +22,7 @@ type AppSettingDto = {
 async function createAuthTokenForNewUser(): Promise<string> {
   const { user } = await createUserFixture({
     name: "Settings User",
-    email: `settings-user-${crypto.randomUUID()}@stayhub.dev`,
+    email: `settings-user-${crypto.randomUUID()}@sogio.dev`,
     password: "password123",
   });
   return createAuthToken(user.id, "user");
@@ -31,7 +31,7 @@ async function createAuthTokenForNewUser(): Promise<string> {
 async function createAuthTokenForAdmin(): Promise<string> {
   const { user } = await createAdminFixture({
     name: "Settings Admin",
-    email: `settings-admin-${crypto.randomUUID()}@stayhub.dev`,
+    email: `settings-admin-${crypto.randomUUID()}@sogio.dev`,
     password: "password123",
   });
   return createAuthToken(user.id, "admin");
@@ -58,7 +58,7 @@ describe("POST /settings", () => {
 
     const res = await createSetting(token, {
       key: "app.name",
-      value: "StayHub",
+      value: "Sogio",
       type: "string",
     });
     const body = (await res.json()) as AppSettingDto;
@@ -66,7 +66,7 @@ describe("POST /settings", () => {
     expect(res.status).toBe(200);
     expect(typeof body.id).toBe("string");
     expect(body.key).toBe("app.name");
-    expect(body.value).toBe("StayHub");
+    expect(body.value).toBe("Sogio");
     expect(body.type).toBe("string");
     expect(body.description).toBeNull();
     expect(typeof body.created_at).toBe("string");
@@ -127,7 +127,7 @@ describe("POST /settings", () => {
 
     const res = await createSetting(token, {
       key: "app.name",
-      value: "StayHub",
+      value: "Sogio",
       type: "string",
     });
 
@@ -137,14 +137,14 @@ describe("POST /settings", () => {
   it("403 — token with forged admin role is rejected when user is 'user' in db", async () => {
     const { user } = await createUserFixture({
       name: "Forged Role User",
-      email: `forged-role-${crypto.randomUUID()}@stayhub.dev`,
+      email: `forged-role-${crypto.randomUUID()}@sogio.dev`,
       password: "password123",
     });
     const forgedToken = await createAuthToken(user.id, "admin");
 
     const res = await createSetting(forgedToken, {
       key: "app.name",
-      value: "StayHub",
+      value: "Sogio",
       type: "string",
     });
 
@@ -156,7 +156,7 @@ describe("POST /settings", () => {
 
     const firstRes = await createSetting(token, {
       key: "app.name",
-      value: "StayHub",
+      value: "Sogio",
       type: "string",
     });
     expect(firstRes.status).toBe(200);
@@ -175,7 +175,7 @@ describe("POST /settings", () => {
       method: "POST",
       body: JSON.stringify({
         key: "app.name",
-        value: "StayHub",
+        value: "Sogio",
         type: "string",
       }),
     });
@@ -200,7 +200,7 @@ describe("POST /settings", () => {
 
     const res = await createSetting(token, {
       key: "app.name",
-      value: "StayHub",
+      value: "Sogio",
       type: "invalid_type",
     });
 
@@ -224,7 +224,7 @@ describe("POST /settings", () => {
 
     const res = await createSetting(token, {
       key: "app.name",
-      value: "StayHub",
+      value: "Sogio",
       type: "string",
       unknown_field: true,
     });
@@ -257,7 +257,7 @@ describe("GET /settings/:id", () => {
 
     const createRes = await createSetting(adminToken, {
       key: "app.name",
-      value: "StayHub",
+      value: "Sogio",
       type: "string",
     });
     const created = (await createRes.json()) as AppSettingDto;
@@ -271,7 +271,7 @@ describe("GET /settings/:id", () => {
     expect(res.status).toBe(200);
     expect(body.id).toBe(created.id);
     expect(body.key).toBe("app.name");
-    expect(body.value).toBe("StayHub");
+    expect(body.value).toBe("Sogio");
     expect(body.type).toBe("string");
   });
 
@@ -347,7 +347,7 @@ describe("GET /settings", () => {
 
     await createSetting(adminToken, {
       key: "app.name",
-      value: "StayHub",
+      value: "Sogio",
       type: "string",
     });
     await createSetting(adminToken, {
@@ -445,7 +445,7 @@ describe("PUT /settings/:id", () => {
 
     const createRes = await createSetting(token, {
       key: "app.name",
-      value: "StayHub",
+      value: "Sogio",
       type: "string",
     });
     const created = (await createRes.json()) as AppSettingDto;
@@ -454,7 +454,7 @@ describe("PUT /settings/:id", () => {
     const res = await api(`/settings/${created.id}`, {
       method: "PUT",
       headers: { Authorization: "Bearer " + token },
-      body: JSON.stringify({ key: "new.key", value: "StayHub" }),
+      body: JSON.stringify({ key: "new.key", value: "Sogio" }),
     });
 
     expect(res.status).toBe(422);
@@ -492,7 +492,7 @@ describe("DELETE /settings/:id", () => {
 
     const createRes = await createSetting(token, {
       key: "app.name",
-      value: "StayHub",
+      value: "Sogio",
       type: "string",
     });
     const created = (await createRes.json()) as AppSettingDto;
@@ -512,7 +512,7 @@ describe("DELETE /settings/:id", () => {
 
     const createRes = await createSetting(adminToken, {
       key: "app.name",
-      value: "StayHub",
+      value: "Sogio",
       type: "string",
     });
     const created = (await createRes.json()) as AppSettingDto;
@@ -551,7 +551,7 @@ describe("DELETE /settings/:id", () => {
 
     const createRes = await createSetting(adminToken, {
       key: "app.name",
-      value: "StayHub",
+      value: "Sogio",
       type: "string",
     });
     const created = (await createRes.json()) as AppSettingDto;

--- a/tests/booking/book_stay.test.ts
+++ b/tests/booking/book_stay.test.ts
@@ -29,7 +29,7 @@ describe("POST /booking/property/:property_id/book", () => {
   it("200 — creates stay with new tenant", async () => {
     const { user } = await createUserFixture({
       name: "João Silva",
-      email: "joao@stayhub.dev",
+      email: "joao@sogio.dev",
       password: "password123",
     });
     const property = await createPropertyFixture({ userId: user.id });
@@ -59,7 +59,7 @@ describe("POST /booking/property/:property_id/book", () => {
   it("200 — generates entrance_code when not provided", async () => {
     const { user } = await createUserFixture({
       name: "João Silva",
-      email: "joao@stayhub.dev",
+      email: "joao@sogio.dev",
       password: "password123",
     });
     const property = await createPropertyFixture({ userId: user.id });
@@ -89,7 +89,7 @@ describe("POST /booking/property/:property_id/book", () => {
   it("200 — reuses existing tenant", async () => {
     const { user } = await createUserFixture({
       name: "João Silva",
-      email: "joao@stayhub.dev",
+      email: "joao@sogio.dev",
       password: "password123",
     });
     const property = await createPropertyFixture({ userId: user.id });
@@ -126,7 +126,7 @@ describe("POST /booking/property/:property_id/book", () => {
   it("401 — rejects request without auth token", async () => {
     const { user } = await createUserFixture({
       name: "João Silva",
-      email: "joao@stayhub.dev",
+      email: "joao@sogio.dev",
       password: "password123",
     });
     const property = await createPropertyFixture({ userId: user.id });
@@ -142,7 +142,7 @@ describe("POST /booking/property/:property_id/book", () => {
   it("401 — rejects request with invalid token", async () => {
     const { user } = await createUserFixture({
       name: "João Silva",
-      email: "joao@stayhub.dev",
+      email: "joao@sogio.dev",
       password: "password123",
     });
     const property = await createPropertyFixture({ userId: user.id });
@@ -159,7 +159,7 @@ describe("POST /booking/property/:property_id/book", () => {
   it("404 — rejects non-existent property_id", async () => {
     const { user } = await createUserFixture({
       name: "João Silva",
-      email: "joao@stayhub.dev",
+      email: "joao@sogio.dev",
       password: "password123",
     });
     const token = await createAuthToken(user.id);
@@ -177,12 +177,12 @@ describe("POST /booking/property/:property_id/book", () => {
   it("404 — rejects property belonging to another user", async () => {
     const { user: user1 } = await createUserFixture({
       name: "Usuário Um",
-      email: "user1@stayhub.dev",
+      email: "user1@sogio.dev",
       password: "password123",
     });
     const { user: user2 } = await createUserFixture({
       name: "Usuário Dois",
-      email: "user2@stayhub.dev",
+      email: "user2@sogio.dev",
       password: "password123",
     });
     const property = await createPropertyFixture({ userId: user1.id });
@@ -200,7 +200,7 @@ describe("POST /booking/property/:property_id/book", () => {
   it("422 — rejects empty body", async () => {
     const { user } = await createUserFixture({
       name: "João Silva",
-      email: "joao@stayhub.dev",
+      email: "joao@sogio.dev",
       password: "password123",
     });
     const property = await createPropertyFixture({ userId: user.id });
@@ -218,7 +218,7 @@ describe("POST /booking/property/:property_id/book", () => {
   it("422 — rejects guests exceeding property capacity", async () => {
     const { user } = await createUserFixture({
       name: "João Silva",
-      email: "joao@stayhub.dev",
+      email: "joao@sogio.dev",
       password: "password123",
     });
     const property = await createPropertyFixture({
@@ -239,7 +239,7 @@ describe("POST /booking/property/:property_id/book", () => {
   it("422 — rejects check_in equal to check_out", async () => {
     const { user } = await createUserFixture({
       name: "João Silva",
-      email: "joao@stayhub.dev",
+      email: "joao@sogio.dev",
       password: "password123",
     });
     const property = await createPropertyFixture({ userId: user.id });
@@ -261,7 +261,7 @@ describe("POST /booking/property/:property_id/book", () => {
   it("409 — rejects overlapping dates for the same property", async () => {
     const { user } = await createUserFixture({
       name: "João Silva",
-      email: "joao@stayhub.dev",
+      email: "joao@sogio.dev",
       password: "password123",
     });
     const property = await createPropertyFixture({ userId: user.id });

--- a/tests/booking/book_stay_tool.test.ts
+++ b/tests/booking/book_stay_tool.test.ts
@@ -99,7 +99,7 @@ describe("book_stay tool", () => {
   it("books a stay and lets the use case generate the entrance_code automatically", async () => {
     const { user } = await createUserFixture({
       name: "João Silva",
-      email: "joao@stayhub.dev",
+      email: "joao@sogio.dev",
       password: "password123",
     });
     const property = await createPropertyFixture({ userId: user.id });
@@ -133,7 +133,7 @@ describe("book_stay tool", () => {
   it("ignores an entrance_code sent by the caller instead of forwarding it to the use case", async () => {
     const { user } = await createUserFixture({
       name: "João Silva",
-      email: "joao@stayhub.dev",
+      email: "joao@sogio.dev",
       password: "password123",
     });
     const property = await createPropertyFixture({ userId: user.id });
@@ -199,12 +199,12 @@ describe("book_stay tool", () => {
   it("rejects booking a property that belongs to another user", async () => {
     const { user: owner } = await createUserFixture({
       name: "João Silva",
-      email: "joao@stayhub.dev",
+      email: "joao@sogio.dev",
       password: "password123",
     });
     const { user: intruder } = await createUserFixture({
       name: "Maria Souza",
-      email: "maria@stayhub.dev",
+      email: "maria@sogio.dev",
       password: "password123",
     });
     const property = await createPropertyFixture({ userId: owner.id });
@@ -229,7 +229,7 @@ describe("book_stay tool", () => {
   it("rejects overlapping dates for a stay already booked on the same property", async () => {
     const { user } = await createUserFixture({
       name: "João Silva",
-      email: "joao@stayhub.dev",
+      email: "joao@sogio.dev",
       password: "password123",
     });
     const property = await createPropertyFixture({ userId: user.id });

--- a/tests/booking/cancel_stay_tool.test.ts
+++ b/tests/booking/cancel_stay_tool.test.ts
@@ -86,7 +86,7 @@ describe("cancel_stay tool", () => {
   it("cancels a stay owned by the authenticated user and reverses its revenue", async () => {
     const { user } = await createUserFixture({
       name: "João Silva",
-      email: "joao@stayhub.dev",
+      email: "joao@sogio.dev",
       password: "password123",
     });
     const property = await createPropertyFixture({ userId: user.id });
@@ -122,12 +122,12 @@ describe("cancel_stay tool", () => {
   it("does not distinguish another owner's stay from a nonexistent one", async () => {
     const { user: owner } = await createUserFixture({
       name: "João Silva",
-      email: "joao@stayhub.dev",
+      email: "joao@sogio.dev",
       password: "password123",
     });
     const { user: intruder } = await createUserFixture({
       name: "Maria Souza",
-      email: "maria@stayhub.dev",
+      email: "maria@sogio.dev",
       password: "password123",
     });
     const property = await createPropertyFixture({ userId: owner.id });

--- a/tests/booking/list_stays.test.ts
+++ b/tests/booking/list_stays.test.ts
@@ -84,7 +84,7 @@ describe("list_stays tool", () => {
   it("returns the stays booked for a property owned by the authenticated user", async () => {
     const { user } = await createUserFixture({
       name: "João Silva",
-      email: "joao@stayhub.dev",
+      email: "joao@sogio.dev",
       password: "password123",
     });
     const property = await createPropertyFixture({ userId: user.id });
@@ -112,12 +112,12 @@ describe("list_stays tool", () => {
   it("rejects listing stays for a property that belongs to another user", async () => {
     const { user: owner } = await createUserFixture({
       name: "João Silva",
-      email: "joao@stayhub.dev",
+      email: "joao@sogio.dev",
       password: "password123",
     });
     const { user: intruder } = await createUserFixture({
       name: "Maria Souza",
-      email: "maria@stayhub.dev",
+      email: "maria@sogio.dev",
       password: "password123",
     });
     const property = await createPropertyFixture({ userId: owner.id });

--- a/tests/core/identity_resolver.test.ts
+++ b/tests/core/identity_resolver.test.ts
@@ -46,7 +46,7 @@ describe("McpIdentityResolver", () => {
   it("resolves the requester and touches the consent's last use for a valid access token", async () => {
     const { user } = await createUserFixture({
       name: "Ada Lovelace",
-      email: "ada@stayhub.dev",
+      email: "ada@sogio.dev",
       password: "password123",
     });
     const app = await createAppRegistrationFixture();
@@ -102,7 +102,7 @@ describe("McpIdentityResolver", () => {
   it("throws UnauthorizedError when the access token has expired", async () => {
     const { user } = await createUserFixture({
       name: "Grace Hopper",
-      email: "grace@stayhub.dev",
+      email: "grace@sogio.dev",
       password: "password123",
     });
     const app = await createAppRegistrationFixture();
@@ -125,7 +125,7 @@ describe("McpIdentityResolver", () => {
   it("throws UnauthorizedError when the credential has been revoked", async () => {
     const { user } = await createUserFixture({
       name: "Katherine Johnson",
-      email: "katherine@stayhub.dev",
+      email: "katherine@sogio.dev",
       password: "password123",
     });
     const app = await createAppRegistrationFixture();
@@ -148,7 +148,7 @@ describe("McpIdentityResolver", () => {
   it("throws UnauthorizedError when the credential was issued for a different audience", async () => {
     const { user } = await createUserFixture({
       name: "Margaret Hamilton",
-      email: "margaret@stayhub.dev",
+      email: "margaret@sogio.dev",
       password: "password123",
     });
     const app = await createAppRegistrationFixture();

--- a/tests/core/mcp_routes.test.ts
+++ b/tests/core/mcp_routes.test.ts
@@ -113,7 +113,7 @@ describe("POST /mcp", () => {
   it("rejects a request whose access token was issued for a different resource", async () => {
     const { user } = await createUserFixture({
       name: "João Silva",
-      email: "joao.wrong-audience@stayhub.dev",
+      email: "joao.wrong-audience@sogio.dev",
       password: "password123",
     });
     const { accessToken } = await createMcpAccessTokenFixture({
@@ -143,7 +143,7 @@ describe("POST /mcp", () => {
   it("lists the 10 registered tools", async () => {
     const { user } = await createUserFixture({
       name: "João Silva",
-      email: "joao.tools-list@stayhub.dev",
+      email: "joao.tools-list@sogio.dev",
       password: "password123",
     });
     const { accessToken: token } = await createMcpAccessTokenFixture({
@@ -183,12 +183,12 @@ describe("POST /mcp", () => {
   it("resolves the caller identity once at the transport gate and returns only their data", async () => {
     const { user: owner } = await createUserFixture({
       name: "João Silva",
-      email: "joao.mcp@stayhub.dev",
+      email: "joao.mcp@sogio.dev",
       password: "password123",
     });
     const { user: otherUser } = await createUserFixture({
       name: "Maria Souza",
-      email: "maria.mcp@stayhub.dev",
+      email: "maria.mcp@sogio.dev",
       password: "password123",
     });
     const ownedProperty = await createPropertyFixture({

--- a/tests/core/mcp_tool.test.ts
+++ b/tests/core/mcp_tool.test.ts
@@ -36,7 +36,7 @@ async function callTool(
   return handler(input, extra);
 }
 
-const fakeUser = { id: "user-1", email: "ada@stayhub.dev" } as User;
+const fakeUser = { id: "user-1", email: "ada@sogio.dev" } as User;
 
 /**
  * Identity resolution no longer happens inside `registerMcpTool` — it

--- a/tests/finance/record_expense.test.ts
+++ b/tests/finance/record_expense.test.ts
@@ -23,7 +23,7 @@ describe("POST /finance/:property_id/expense", () => {
   it("204 — records expense for a property owned by the user", async () => {
     const { user } = await createUserFixture({
       name: "João Silva",
-      email: "joao@stayhub.dev",
+      email: "joao@sogio.dev",
       password: "password123",
     });
     const property = await createPropertyFixture({ userId: user.id });
@@ -41,7 +41,7 @@ describe("POST /finance/:property_id/expense", () => {
   it("401 — rejects request without auth token", async () => {
     const { user } = await createUserFixture({
       name: "João Silva",
-      email: "joao@stayhub.dev",
+      email: "joao@sogio.dev",
       password: "password123",
     });
     const property = await createPropertyFixture({ userId: user.id });
@@ -57,7 +57,7 @@ describe("POST /finance/:property_id/expense", () => {
   it("404 — rejects non-existent property_id", async () => {
     const { user } = await createUserFixture({
       name: "João Silva",
-      email: "joao@stayhub.dev",
+      email: "joao@sogio.dev",
       password: "password123",
     });
     const token = await createAuthToken(user.id);
@@ -75,12 +75,12 @@ describe("POST /finance/:property_id/expense", () => {
   it("404 — rejects property belonging to another user", async () => {
     const { user: user1 } = await createUserFixture({
       name: "Usuário Um",
-      email: "user1@stayhub.dev",
+      email: "user1@sogio.dev",
       password: "password123",
     });
     const { user: user2 } = await createUserFixture({
       name: "Usuário Dois",
-      email: "user2@stayhub.dev",
+      email: "user2@sogio.dev",
       password: "password123",
     });
     const property = await createPropertyFixture({ userId: user1.id });
@@ -98,7 +98,7 @@ describe("POST /finance/:property_id/expense", () => {
   it("422 — rejects empty body", async () => {
     const { user } = await createUserFixture({
       name: "João Silva",
-      email: "joao@stayhub.dev",
+      email: "joao@sogio.dev",
       password: "password123",
     });
     const property = await createPropertyFixture({ userId: user.id });
@@ -116,7 +116,7 @@ describe("POST /finance/:property_id/expense", () => {
   it("422 — rejects category outside the closed vocabulary", async () => {
     const { user } = await createUserFixture({
       name: "João Silva",
-      email: "joao@stayhub.dev",
+      email: "joao@sogio.dev",
       password: "password123",
     });
     const property = await createPropertyFixture({ userId: user.id });
@@ -134,7 +134,7 @@ describe("POST /finance/:property_id/expense", () => {
   it("200 — reads a historical movement with a category outside the closed vocabulary", async () => {
     const { user } = await createUserFixture({
       name: "João Silva",
-      email: "joao@stayhub.dev",
+      email: "joao@sogio.dev",
       password: "password123",
     });
     const property = await createPropertyFixture({ userId: user.id });

--- a/tests/finance/record_expense_tool.test.ts
+++ b/tests/finance/record_expense_tool.test.ts
@@ -68,7 +68,7 @@ describe("record_expense tool", () => {
   it("records an expense for a property owned by the authenticated user", async () => {
     const { user } = await createUserFixture({
       name: "João Silva",
-      email: "joao@stayhub.dev",
+      email: "joao@sogio.dev",
       password: "password123",
     });
     const property = await createPropertyFixture({ userId: user.id });
@@ -111,12 +111,12 @@ describe("record_expense tool", () => {
   it("rejects an expense for a property that belongs to another user", async () => {
     const { user: owner } = await createUserFixture({
       name: "João Silva",
-      email: "joao@stayhub.dev",
+      email: "joao@sogio.dev",
       password: "password123",
     });
     const { user: intruder } = await createUserFixture({
       name: "Maria Souza",
-      email: "maria@stayhub.dev",
+      email: "maria@sogio.dev",
       password: "password123",
     });
     const property = await createPropertyFixture({ userId: owner.id });

--- a/tests/helpers/fixtures/delegated_access.ts
+++ b/tests/helpers/fixtures/delegated_access.ts
@@ -84,7 +84,7 @@ export async function createAuthorizationRequestFixture(input: {
     code_challenge: "test-code-challenge",
     code_challenge_method: "S256",
     scope: "mcp",
-    resource: "https://api.stayhub.dev/mcp",
+    resource: "https://api.sogio.dev/mcp",
     expires_at: input.expiresAt ?? new Date(Date.now() + 5 * 60 * 1000),
   });
 
@@ -110,7 +110,7 @@ export async function createAuthorizationCodeFixture(input: {
     code_challenge: "test-code-challenge",
     code_challenge_method: "S256",
     scope: "mcp",
-    resource: "https://api.stayhub.dev/mcp",
+    resource: "https://api.sogio.dev/mcp",
     expires_at: input.expiresAt ?? new Date(Date.now() + 60 * 1000),
   });
 
@@ -141,7 +141,7 @@ export async function issueCredentialFixture(input: {
       input.accessTokenExpiresAt ?? new Date(Date.now() + 60 * 60 * 1000),
     refresh_token_digest: refresh.digest,
     refresh_token_expires_at: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000),
-    resource: input.resource ?? "https://api.stayhub.dev/mcp",
+    resource: input.resource ?? "https://api.sogio.dev/mcp",
   });
 
   const issuedCredential = await repository.issue(entity);

--- a/tests/property_management/create_property_setting_tool.test.ts
+++ b/tests/property_management/create_property_setting_tool.test.ts
@@ -63,7 +63,7 @@ describe("create_property_setting tool", () => {
   it("creates a setting scoped to a property administered by the authenticated user", async () => {
     const { user } = await createUserFixture({
       name: "João Silva",
-      email: "joao@stayhub.dev",
+      email: "joao@sogio.dev",
       password: "password123",
     });
     const property = await createPropertyFixture({ userId: user.id });
@@ -99,12 +99,12 @@ describe("create_property_setting tool", () => {
   it("does not distinguish another owner's property from a nonexistent one", async () => {
     const { user: owner } = await createUserFixture({
       name: "João Silva",
-      email: "joao@stayhub.dev",
+      email: "joao@sogio.dev",
       password: "password123",
     });
     const { user: intruder } = await createUserFixture({
       name: "Maria Souza",
-      email: "maria@stayhub.dev",
+      email: "maria@sogio.dev",
       password: "password123",
     });
     const ownerProperty = await createPropertyFixture({ userId: owner.id });

--- a/tests/property_management/delete_property_setting_tool.test.ts
+++ b/tests/property_management/delete_property_setting_tool.test.ts
@@ -78,7 +78,7 @@ describe("delete_property_setting tool", () => {
   it("soft-deletes a setting owned by the authenticated user's property and redacts its value/description", async () => {
     const { user } = await createUserFixture({
       name: "João Silva",
-      email: "joao@stayhub.dev",
+      email: "joao@sogio.dev",
       password: "password123",
     });
     const property = await createPropertyFixture({ userId: user.id });
@@ -107,12 +107,12 @@ describe("delete_property_setting tool", () => {
   it("does not distinguish another owner's property setting from a nonexistent one", async () => {
     const { user: owner } = await createUserFixture({
       name: "João Silva",
-      email: "joao@stayhub.dev",
+      email: "joao@sogio.dev",
       password: "password123",
     });
     const { user: intruder } = await createUserFixture({
       name: "Maria Souza",
-      email: "maria@stayhub.dev",
+      email: "maria@sogio.dev",
       password: "password123",
     });
     const ownerProperty = await createPropertyFixture({ userId: owner.id });

--- a/tests/property_management/get_property_setting_tool.test.ts
+++ b/tests/property_management/get_property_setting_tool.test.ts
@@ -74,7 +74,7 @@ describe("get_property_setting tool", () => {
   it("returns a setting owned by the authenticated user's property", async () => {
     const { user } = await createUserFixture({
       name: "João Silva",
-      email: "joao@stayhub.dev",
+      email: "joao@sogio.dev",
       password: "password123",
     });
     const property = await createPropertyFixture({ userId: user.id });
@@ -98,12 +98,12 @@ describe("get_property_setting tool", () => {
   it("does not distinguish another owner's property setting from a nonexistent one", async () => {
     const { user: owner } = await createUserFixture({
       name: "João Silva",
-      email: "joao@stayhub.dev",
+      email: "joao@sogio.dev",
       password: "password123",
     });
     const { user: intruder } = await createUserFixture({
       name: "Maria Souza",
-      email: "maria@stayhub.dev",
+      email: "maria@sogio.dev",
       password: "password123",
     });
     const ownerProperty = await createPropertyFixture({ userId: owner.id });

--- a/tests/property_management/list_properties.test.ts
+++ b/tests/property_management/list_properties.test.ts
@@ -64,12 +64,12 @@ describe("list_properties tool", () => {
   it("returns only the properties administered by the authenticated user", async () => {
     const { user: owner } = await createUserFixture({
       name: "João Silva",
-      email: "joao@stayhub.dev",
+      email: "joao@sogio.dev",
       password: "password123",
     });
     const { user: otherUser } = await createUserFixture({
       name: "Maria Souza",
-      email: "maria@stayhub.dev",
+      email: "maria@sogio.dev",
       password: "password123",
     });
     const ownedProperty = await createPropertyFixture({

--- a/tests/property_management/list_property_settings_tool.test.ts
+++ b/tests/property_management/list_property_settings_tool.test.ts
@@ -74,7 +74,7 @@ describe("list_property_settings tool", () => {
   it("returns only the settings scoped to the requested property, paginated", async () => {
     const { user } = await createUserFixture({
       name: "João Silva",
-      email: "joao@stayhub.dev",
+      email: "joao@sogio.dev",
       password: "password123",
     });
     const property = await createPropertyFixture({ userId: user.id });
@@ -105,12 +105,12 @@ describe("list_property_settings tool", () => {
   it("does not distinguish another owner's property from a nonexistent one", async () => {
     const { user: owner } = await createUserFixture({
       name: "João Silva",
-      email: "joao@stayhub.dev",
+      email: "joao@sogio.dev",
       password: "password123",
     });
     const { user: intruder } = await createUserFixture({
       name: "Maria Souza",
-      email: "maria@stayhub.dev",
+      email: "maria@sogio.dev",
       password: "password123",
     });
     const ownerProperty = await createPropertyFixture({ userId: owner.id });

--- a/tests/property_management/update_property_setting_tool.test.ts
+++ b/tests/property_management/update_property_setting_tool.test.ts
@@ -77,7 +77,7 @@ describe("update_property_setting tool", () => {
   it("updates a setting owned by the authenticated user's property", async () => {
     const { user } = await createUserFixture({
       name: "João Silva",
-      email: "joao@stayhub.dev",
+      email: "joao@sogio.dev",
       password: "password123",
     });
     const property = await createPropertyFixture({ userId: user.id });
@@ -112,12 +112,12 @@ describe("update_property_setting tool", () => {
   it("does not distinguish another owner's property setting from a nonexistent one", async () => {
     const { user: owner } = await createUserFixture({
       name: "João Silva",
-      email: "joao@stayhub.dev",
+      email: "joao@sogio.dev",
       password: "password123",
     });
     const { user: intruder } = await createUserFixture({
       name: "Maria Souza",
-      email: "maria@stayhub.dev",
+      email: "maria@sogio.dev",
       password: "password123",
     });
     const ownerProperty = await createPropertyFixture({ userId: owner.id });


### PR DESCRIPTION
## Summary
- Renames the product/brand name from "StayHub" to "Sogio" across source comments, docs, OpenAPI/MCP metadata, package.json, docker-compose.yml, and test fixtures.
- No domain terminology changes: `Stay`, `BookingProperty`, routes, tables, etc. are untouched — only the `stayhub`/`StayHub` brand token was replaced.
- `cors.middleware.ts` changes are comments only; the actual origin-matching logic (`frontBaseUrl`) is untouched.
- Plan and architect sign-off: `.claude/plans/2026-08-15-renomear-stayhub-para-sogio.md`.

## Known follow-ups (intentionally out of scope here)
- `.github/workflows/deploy.yml` (`cd stayhub_api`, `pm2 restart stayhub_api`) — real production VPS identifiers, left untouched until a coordinated production rename.
- `bun.lock`'s internal workspace `name` field still says `stayhub-api` (cosmetic only, doesn't affect install/build/runtime) — a full lockfile regen would have bumped ~135 unrelated transitive dependencies, out of scope for a branding rename.
- Local `.env`/`.env.test` (gitignored, not in this PR) and the local Docker DB rename happen after merge.
- GitHub repo rename (`stayhub-api` -> `sogio-api`) and local folder rename happen after merge.

## Test plan
- [x] `bun run lint:check`
- [x] `bun run format:check`
- [x] `bun run typecheck`
- [ ] `bun run test` (blocked locally on `.env.test`, which points at the old DB name — will run after the post-merge local DB cutover)

🤖 Generated with [Claude Code](https://claude.com/claude-code)