### PR TITLE
feat: send password reset email as branded HTML template

### DIFF
--- a/src/auth/application/service/password_reset_email_composer.ts
+++ b/src/auth/application/service/password_reset_email_composer.ts
@@ -1,29 +1,142 @@
 import type { EmailMessage } from "../../../core/application/email/email_service";
+import { escapeHtml } from "../../../core/infra/http/utils/escape_html";
 
 const RESET_PASSWORD_FRONT_PATH = "/reset-password";
+
+function renderHtml(params: {
+  name: string;
+  email: string;
+  resetLink: string;
+  expiryMinutes: number;
+}): string {
+  const name = escapeHtml(params.name);
+  const email = escapeHtml(params.email);
+  const resetLink = escapeHtml(params.resetLink);
+  const expiryMinutes = params.expiryMinutes;
+
+  return `<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="color-scheme" content="light dark">
+<meta name="supported-color-schemes" content="light dark">
+<title>Redefinir senha</title>
+<!--[if mso]>
+<style type="text/css">
+  body, table, td, a { font-family: Arial, Helvetica, sans-serif !important; }
+</style>
+<![endif]-->
+<style type="text/css">
+  @media only screen and (max-width: 620px) {
+    .wrap { width: 100% !important; }
+    .pad { padding-left: 24px !important; padding-right: 24px !important; }
+    .h1 { font-size: 26px !important; line-height: 32px !important; }
+  }
+</style>
+</head>
+<body style="margin:0; padding:0; background-color:#eceae4;">
+<span style="display:none; visibility:hidden; opacity:0; color:transparent; height:0; width:0; max-height:0; max-width:0; overflow:hidden; mso-hide:all;">Redefina sua senha do Sogio com o link seguro deste email — ele expira em ${expiryMinutes} minutos.</span>
+
+<table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="background-color:#eceae4;">
+  <tr>
+    <td align="center" style="padding:32px 12px;">
+
+      <table role="presentation" class="wrap" cellpadding="0" cellspacing="0" border="0" width="600" style="width:600px; max-width:600px; background-color:#fbfaf7; border:1px solid #ddd9d0; border-radius:6px;">
+
+        <tr>
+          <td class="pad" style="padding:28px 40px 24px 40px; border-bottom:1px solid #e6e2d9;">
+            <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%">
+              <tr>
+                <td align="left" style="font-family:Georgia, 'Times New Roman', serif; font-size:19px; line-height:24px; mso-line-height-rule:exactly; letter-spacing:0.5px; color:#1f2420; font-weight:bold;">Sogio</td>
+                <td align="right" style="font-family:Arial, Helvetica, sans-serif; font-size:11px; line-height:24px; mso-line-height-rule:exactly; letter-spacing:1.5px; text-transform:uppercase; color:#7b7768;">Segurança da conta</td>
+              </tr>
+            </table>
+          </td>
+        </tr>
+
+        <tr>
+          <td class="pad" style="padding:44px 40px 0 40px;">
+            <h1 class="h1" style="margin:0 0 18px 0; font-family:Georgia, 'Times New Roman', serif; font-size:31px; line-height:38px; mso-line-height-rule:exactly; font-weight:normal; color:#1f2420;">Esqueceu sua senha?</h1>
+            <p style="margin:0 0 16px 0; font-family:Arial, Helvetica, sans-serif; font-size:16px; line-height:26px; mso-line-height-rule:exactly; color:#4a4c44;">Olá, ${name} — recebemos uma solicitação para redefinir a senha da conta associada a <span style="color:#1f2420; font-weight:bold;">${email}</span>. Escolha uma nova senha usando o botão abaixo.</p>
+            <p style="margin:0 0 32px 0; font-family:Arial, Helvetica, sans-serif; font-size:16px; line-height:26px; mso-line-height-rule:exactly; color:#4a4c44;">Este link funciona uma única vez e expira ${expiryMinutes} minutos após a solicitação.</p>
+          </td>
+        </tr>
+
+        <tr>
+          <td class="pad" align="left" style="padding:0 40px 32px 40px;">
+            <table role="presentation" cellpadding="0" cellspacing="0" border="0">
+              <tr>
+                <td bgcolor="#2EAE9F" style="border-radius:4px;">
+                  <a href="${resetLink}" style="display:block; padding:15px 34px; font-family:Arial, Helvetica, sans-serif; font-size:16px; line-height:20px; mso-line-height-rule:exactly; font-weight:bold; color:#fbfaf7; text-decoration:none; border-radius:4px; background-color:#2EAE9F;">Definir nova senha</a>
+                </td>
+              </tr>
+            </table>
+          </td>
+        </tr>
+
+        <tr>
+          <td class="pad" style="padding:0 40px 36px 40px;">
+            <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="background-color:#f2efe8; border:1px solid #e6e2d9; border-radius:4px;">
+              <tr>
+                <td style="padding:18px 20px;">
+                  <p style="margin:0 0 8px 0; font-family:Arial, Helvetica, sans-serif; font-size:12px; line-height:18px; mso-line-height-rule:exactly; letter-spacing:1px; text-transform:uppercase; color:#7b7768;">O botão não está funcionando?</p>
+                  <p style="margin:0; font-family:Arial, Helvetica, sans-serif; font-size:13px; line-height:21px; mso-line-height-rule:exactly; color:#4a4c44; word-break:break-all;"><a href="${resetLink}" style="color:#2f5d4a; text-decoration:underline;">${resetLink}</a></p>
+                </td>
+              </tr>
+            </table>
+          </td>
+        </tr>
+
+        <tr>
+          <td class="pad" style="padding:0 40px 44px 40px; border-top:1px solid #e6e2d9;">
+            <p style="margin:28px 0 0 0; font-family:Arial, Helvetica, sans-serif; font-size:14px; line-height:23px; mso-line-height-rule:exactly; color:#6c6e64;">Não foi você quem pediu isso? Pode ignorar este email com segurança — sua senha continua a mesma. Se precisar de ajuda, responda esta mensagem ou escreva para <a href="mailto:contact@sogio.app" style="color:#2f5d4a; text-decoration:underline;">contact@sogio.app</a>.</p>
+          </td>
+        </tr>
+
+      </table>
+
+    </td>
+  </tr>
+</table>
+</body>
+</html>`;
+}
 
 /**
  * Monta o email de recuperação de senha — conteúdo é linguagem de negócio de
  * Auth, por isso vive aqui e não em `core` (D6/§2.8 do plano). O token vai no
  * link do front, nunca em texto avulso — é o próprio front que o extrai e o
  * envia no corpo da chamada à API que consome o token (R9).
+ *
+ * `name`/`email` são interpolados no HTML via `escapeHtml` — `name` é texto
+ * livre do usuário (até 100 caracteres, sem restrição de caracteres) e não
+ * pode quebrar a marcação nem sequestrar o link do botão.
  */
 export function composePasswordResetEmail(
   frontBaseUrl: string,
+  name: string,
   email: string,
-  token: string
+  token: string,
+  requestTtlMs: number
 ): EmailMessage {
   const resetLink = `${frontBaseUrl}${RESET_PASSWORD_FRONT_PATH}?token=${encodeURIComponent(token)}`;
+  const expiryMinutes = Math.round(requestTtlMs / 60_000);
 
   return {
     to: email,
     subject: "Redefinição de senha - Sogio",
-    body: [
+    text: [
+      `Olá, ${name},`,
+      "",
       "Recebemos uma solicitação para redefinir a senha da sua conta Sogio.",
       "",
       `Para continuar, acesse: ${resetLink}`,
       "",
-      "Se você não solicitou isso, ignore este email — sua senha continua a mesma. O link expira em breve.",
+      `Este link funciona uma única vez e expira ${expiryMinutes} minutos após a solicitação.`,
+      "",
+      "Se você não solicitou isso, ignore este email — sua senha continua a mesma.",
     ].join("\n"),
+    html: renderHtml({ name, email, resetLink, expiryMinutes }),
   };
 }

--- a/src/auth/application/use_case/request_password_reset.ts
+++ b/src/auth/application/use_case/request_password_reset.ts
@@ -77,8 +77,10 @@ export class RequestPasswordResetUseCase implements UseCase<Input, Output> {
 
     const message = composePasswordResetEmail(
       this.frontBaseUrl,
+      user.name,
       user.email,
-      secret
+      secret,
+      this.requestTtlMs
     );
 
     /**

--- a/src/auth/presentation/controller/delegated_access/oauth_authorize_error_page.ts
+++ b/src/auth/presentation/controller/delegated_access/oauth_authorize_error_page.ts
@@ -1,11 +1,4 @@
-function escapeHtml(value: string): string {
-  return value
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;")
-    .replace(/'/g, "&#39;");
-}
+import { escapeHtml } from "../../../../core/infra/http/utils/escape_html";
 
 /**
  * Mode A error page (E2): rendered whenever there is no verified redirect

--- a/src/core/application/email/email_service.ts
+++ b/src/core/application/email/email_service.ts
@@ -1,7 +1,10 @@
 export type EmailMessage = {
   to: string;
   subject: string;
-  body: string;
+  /** Plain-text body — always required as the fallback for clients that don't render HTML. */
+  text: string;
+  /** Optional rich rendering; the composer decides whether a message needs one. */
+  html?: string;
 };
 
 /**

--- a/src/core/infra/email/resend_email_service.ts
+++ b/src/core/infra/email/resend_email_service.ts
@@ -18,7 +18,8 @@ export class ResendEmailService implements EmailService {
       from: this.#from,
       to: message.to,
       subject: message.subject,
-      text: message.body,
+      text: message.text,
+      ...(message.html ? { html: message.html } : {}),
     });
 
     if (result.error) {

--- a/src/core/infra/http/utils/escape_html.ts
+++ b/src/core/infra/http/utils/escape_html.ts
@@ -1,0 +1,9 @@
+/** Escapes the five HTML-significant characters for safe interpolation into markup. */
+export function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}

--- a/tests/helpers/fixtures/password_reset.ts
+++ b/tests/helpers/fixtures/password_reset.ts
@@ -33,7 +33,7 @@ export class SilentLogger implements Logger {
 }
 
 export function extractResetTokenFromEmail(message: EmailMessage): string {
-  const match = message.body.match(/token=(\S+)/);
+  const match = message.text.match(/token=(\S+)/);
 
   if (!match?.[1]) {
     throw new Error("No reset token found in the composed email body");


### PR DESCRIPTION
## Summary
- Replaces the plain-text-only password reset email with the provided HTML template, translated to pt-BR, plus a plain-text fallback (both sent — Resend/most clients prefer `html` when present, `text` covers clients that don't render it)
- Copy is now dynamic: greets the user by name, and states the actual expiry in minutes (derived from `PASSWORD_RESET_REQUEST_TTL_SECONDS`) instead of a vague "expires soon" — also fixes an inconsistency in the original template (preheader said 30 min, body said 60 min)
- `EmailMessage` gains an optional `html` field (`text` stays required as the fallback); `ResendEmailService` passes it through when present
- User-supplied `name`/`email` are HTML-escaped before interpolation, since `name` is free text (up to 100 chars, no character restriction) and must not be able to break the markup or hijack the button link
- Extracted `escapeHtml` to `core/infra/http/utils/` — it was previously duplicated inline in `oauth_authorize_error_page.ts`; both now share one implementation

## Test plan
- [x] `bun run test` — 178 pass, 0 fail (existing `password_reset.test.ts` suite covers the composer indirectly through `RequestPasswordResetUseCase`; updated the `FakeEmailService` fixture for the `body` → `text` rename)
- [x] `bunx tsc --noEmit`, `bun run lint:check`, `bun run format` — all clean
- [ ] Visual check of the rendered HTML in an actual inbox (Gmail/Outlook rendering quirks) — not done in this session, recommend before/after merge